### PR TITLE
0.2.x pure va config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 *.bkup
 *.old
 
+# Debugging files
+*.bc
+
 # Mac files
 .DS_Store
 
@@ -58,6 +61,7 @@ src/general/populator
 
 #scons
 .sconsign.dblite
+.sconf_temp
 
 #binaries
 bin/*

--- a/SConstruct
+++ b/SConstruct
@@ -493,6 +493,19 @@ if not env['IS_INSTALL']:
 ##### Configuration checks
 if 'configure' in COMMAND_LINE_TARGETS:
   
+  def CheckCXX11(conf):
+    conf.Message('Checking for c++11... ') 
+    
+    ret = conf.TryRun("""
+    int main() {
+      int a = 1;
+      auto b = a;
+      return 0;
+    }
+    """, '.cpp')[0]
+    conf.Result(ret)
+    return ret
+  
   def CheckBoost_prefix(conf, boost_prefix):
     conf.Message('BOOST_PREFIX: ' + str(boost_prefix) + '\n')
     conf.Message('Checking for boost headers... ') 
@@ -598,6 +611,7 @@ if 'configure' in COMMAND_LINE_TARGETS:
     env.Clone(LIBPATH=install_lib_paths,
               CPPPATH=cpppath),
     custom_tests = {
+      'CheckCXX11' : CheckCXX11,
       'CheckBoost_prefix' : CheckBoost_prefix,
       'CheckBoost_libname' : CheckBoost_libname,
       'CheckBoost_version' : CheckBoost_version,
@@ -610,6 +624,8 @@ if 'configure' in COMMAND_LINE_TARGETS:
   
   # Note: CheckLib with autoadd=1 (default), because some libraries depend on each other
   
+  if not conf.CheckCXX11():
+    if_failed("C++11 is required. Please check your compiler.")
   for x in ['z', 'dl']:
     if not conf.CheckLib(env[x]):
       if_failed("Please check your installation")

--- a/include/casm/clex/ConfigMapping.hh
+++ b/include/casm/clex/ConfigMapping.hh
@@ -23,7 +23,13 @@ namespace CASM {
                  };
 
     ///\brief Default construction not allowed -- this constructor provides an override
-    ConfigMapper(NullInitializer) : m_pclex(nullptr) {}
+    ConfigMapper(NullInitializer) :
+      m_pclex(nullptr),
+      m_lattice_weight(0.5),
+      m_max_volume_change(0.5),
+      m_min_va_frac(0.),
+      m_max_va_frac(1.) {
+    }
 
     ///\brief Construct and initialize a ConfigMapper
     ///\param _pclex the PrimClex that describes the crystal template
@@ -54,7 +60,7 @@ namespace CASM {
     ///\param _tol tolerance for mapping comparisons
     ConfigMapper(PrimClex &_pclex,
                  double _lattice_weight,
-                 double _max_volume_change = 0.25,
+                 double _max_volume_change = 0.5,
                  int _options = robust, // this should actually be a bitwise-OR of ConfigMapper::Options
                  double _tol = TOL);
 
@@ -70,6 +76,27 @@ namespace CASM {
     double lattice_weight() const {
       return m_lattice_weight;
     }
+
+    void set_lattice_weight(double _lw) {
+      m_lattice_weight = max(min(_lw, 1.0), 1e-9);
+    }
+
+    double min_va_frac() const {
+      return m_min_va_frac;
+    }
+
+    void set_min_va_frac(double _min_va) {
+      m_min_va_frac = max(_min_va, 0.);
+    }
+
+    double max_va_frac() const {
+      return m_max_va_frac;
+    }
+
+    void set_max_va_frac(double _max_va) {
+      m_max_va_frac = min(_max_va, 1.);
+    }
+
 
     ///\brief imports structure specified by 'pos_path' into primclex() by finding optimal mapping
     ///       and then setting displacements and strain to zero (only the mapped occupation is preserved)
@@ -238,7 +265,10 @@ namespace CASM {
   private:
     PrimClex *m_pclex;
     mutable std::map<Index, std::vector<Lattice> > m_superlat_map;
-    double m_lattice_weight, m_max_volume_change;
+    double m_lattice_weight;
+    double m_max_volume_change;
+    double m_min_va_frac;
+    double m_max_va_frac;
     bool m_robust_flag, m_strict_flag, m_rotate_flag;
     double m_tol;
     std::vector<std::pair<std::string, Index> > m_fixed_components;

--- a/include/casm/clex/ConfigSelection.hh
+++ b/include/casm/clex/ConfigSelection.hh
@@ -78,7 +78,7 @@ namespace CASM {
     bool m_selected_only;
   };
 
-  template <bool IsConst = false>
+  template <bool IsConst>
   class ConfigSelection {
   public:
     typedef CASM_TMP::ConstSwitch<IsConst, PrimClex> PrimClexType;

--- a/include/casm/completer/Handlers.hh
+++ b/include/casm/completer/Handlers.hh
@@ -125,7 +125,7 @@ namespace CASM {
       //-------------------------------------------------------------------------------------//
 
       ///Add --config suboption (defaults to MASTER)
-      void add_configlist_suboption();
+      void add_configlist_suboption(const fs::path &_default = "MASTER");
 
       ///The selection string to go with add_config_suboption
       fs::path m_selection_path;
@@ -136,7 +136,7 @@ namespace CASM {
       //----------------------------//
 
       ///Add --configs suboption (defaults to MASTER)
-      void add_configlists_suboption();
+      void add_configlists_suboption(const fs::path &_default = "MASTER");
 
       ///The selection string to go with add_config_suboption
       std::vector<fs::path> m_selection_paths;
@@ -494,6 +494,10 @@ namespace CASM {
 
       double lattice_weight() const;
 
+      double min_va_frac() const;
+
+      double max_va_frac() const;
+
       const std::vector<fs::path> &pos_vec() const;
 
       const fs::path &batch_path() const;
@@ -506,6 +510,10 @@ namespace CASM {
       double m_vol_tolerance;
 
       double m_lattice_weight;
+
+      double m_min_va_frac;
+
+      double m_max_va_frac;
 
       std::vector<fs::path> m_pos_vec;
 
@@ -701,11 +709,17 @@ namespace CASM {
 
       using OptionHandlerBase::coordtype_enum;
 
+      using OptionHandlerBase::selection_path;
+
       UpdateOption();
 
       double vol_tolerance() const;
 
       double lattice_weight() const;
+
+      double min_va_frac() const;
+
+      double max_va_frac() const;
 
     private:
 
@@ -714,6 +728,10 @@ namespace CASM {
       double m_vol_tolerance;
 
       double m_lattice_weight;  //TODO: Push to base? Other commands use this
+
+      double m_min_va_frac;
+
+      double m_max_va_frac;
 
     };
 

--- a/include/casm/crystallography/Lattice.hh
+++ b/include/casm/crystallography/Lattice.hh
@@ -45,7 +45,7 @@ namespace CASM {
     /// \brief Return scaled copy of this lattice (Note: Volume will be scaled by scale^3)
     Lattice scaled_lattice(double scale) const;
 
-    /// \brief Return angle between lattice vectors (*this)[(i+1)%3] and (*this)[(i+2)%3]
+    /// \brief Return angle between lattice vectors (*this)[(i+1)%3] and (*this)[(i+2)%3], in degrees
     double angle(Index i)const;
 
     /// \brief Return length of i'th lattice vector
@@ -56,10 +56,19 @@ namespace CASM {
       return lat_column_mat().determinant();
     }
 
+    /// \brief Return voronoi table, which specifies outward-pointing normals of Lattice Voronoi cell.
+    /// outward-pointing normals are given as rows of the matrix, and defined such that
+    /// if (voronoi_table()*coord.cart()).maxCoeff()>1, then 'coord' is outside of the voronoi cell
+    Eigen::MatrixXd const &voronoi_table() const {
+      if(!m_voronoi_table.size()) {
+        _generate_voronoi_table();
+      }
+      return m_voronoi_table;
+    }
+
     /// \brief Radius of the largest sphere that fits wholly within the voronoi cell
     double inner_voronoi_radius() const {
-      if(voronoi_table.empty())
-        generate_voronoi_table();
+      voronoi_table();
       return m_inner_voronoi_radius;
     }
 
@@ -184,10 +193,10 @@ namespace CASM {
   private:
 
     /// \brief populate voronoi information.
-    void generate_voronoi_table() const;
+    void _generate_voronoi_table() const;
 
     mutable double m_inner_voronoi_radius;
-    mutable std::vector<Eigen::Vector3d> voronoi_table;
+    mutable Eigen::MatrixXd m_voronoi_table;
 
     //Coordinate Conversion Matrices
     //0 is fractional to cartesion; 1 is cartesian to fractional

--- a/src/casm/app/import.cc
+++ b/src/casm/app/import.cc
@@ -28,6 +28,13 @@ namespace CASM {
       return m_vol_tolerance;
     }
 
+    double ImportOption::min_va_frac() const {
+      return m_min_va_frac;
+    }
+
+    double ImportOption::max_va_frac() const {
+      return m_max_va_frac;
+    }
     const std::vector<fs::path> &ImportOption::pos_vec() const {
       return m_pos_vec;
     }
@@ -46,6 +53,10 @@ namespace CASM {
       ("min-energy", "Resolve mapping conflicts based on energy rather than deformation.")
       ("max-vol-change", po::value<double>(&m_vol_tolerance)->default_value(0.25),
        "Adjusts range of SCEL volumes searched while mapping imported structure onto ideal crystal (only necessary if the presence of vacancies makes the volume ambiguous). Default is +/- 25% of relaxed_vol/prim_vol. Smaller values yield faster import, larger values may yield more accurate mapping.")
+      ("max-va-frac", po::value<double>(&m_max_va_frac)->default_value(0.5),
+       "Places upper bound on the fraction of sites that are allowed to be vacant after imported structure is mapped onto the ideal crystal. Smaller values yield faster execution, larger values may yield more accurate mapping. Has no effect if supercell volume can be inferred from the number of atoms in the structure. Default value allows up to 50% of sites to be vacant.")
+      ("min-va-frac", po::value<double>(&m_min_va_frac)->default_value(0.),
+       "Places lower bound on the fraction of sites that are allowed to be vacant after imported structure is mapped onto the ideal crystal. Nonzero values may yield faster execution if updating configurations that are known to have a large number of vacancies, at potential sacrifice of mapping accuracy.  Has no effect if supercell volume can be inferred from the number of atoms in the structure. Default value allows as few as 0% of sites to be vacant.")
       ("batch,b", po::value<fs::path>(&m_batch_path)->value_name(ArgHandler::path()), "Path to batch file, which should list one structure file path per line (can be used in combination with --pos)")
       ("rotate,r", "Rotate structure to be consistent with setting of PRIM")
       ("ideal,i", "Assume imported structures are unstrained (ideal) for faster importing. Can be slower if used on deformed structures, in which case more robust methods will be used")
@@ -194,6 +205,8 @@ namespace CASM {
     if(vm.count("strict")) map_opt |= ConfigMapper::strict;
     if(!vm.count("ideal")) map_opt |= ConfigMapper::robust;
     ConfigMapper configmapper(primclex, lattice_weight, vol_tol, map_opt, tol);
+    configmapper.set_min_va_frac(import_opt.min_va_frac());
+    configmapper.set_max_va_frac(import_opt.max_va_frac());
 
 
     // import_map keeps track of mapping collisions -- only used if vm.count("data")

--- a/src/casm/app/super.cc
+++ b/src/casm/app/super.cc
@@ -128,12 +128,12 @@ namespace CASM {
             return ERR_INVALID_ARG;
           }
           if(configname.size() > 1 || scelname.size() > 1 || tmatfile.size() > 1) {
-            std::cerr << "ERROR: more than one --configname, --scelname, or --transf-mat argument "
+            std::cerr << "ERROR: more than one --confignames, --scelnames, or --transf-mat argument "
                       "is only allowed for option --duper" << std::endl;
             return ERR_INVALID_ARG;
           }
           if(config_path.size() > 0) {
-            std::cerr << "ERROR: the --config option is only allowed with option --duper" << std::endl;
+            std::cerr << "ERROR: the --configs option is only allowed with option --duper" << std::endl;
             return ERR_INVALID_ARG;
           }
         }
@@ -159,7 +159,7 @@ namespace CASM {
                   "  casm super --structure POSCAR --transf-mat T                        \n" <<
                   "  - Print superstructure of a POSCAR                                  \n" <<
                   "                                                                      \n" <<
-                  "  casm super --configname configname --transf-mat T                   \n" <<
+                  "  casm super --confignames configname --transf-mat T                   \n" <<
                   "  - Print superstructure of a configuration                           \n" <<
                   "                                                                      \n" <<
                   "  casm super --structure POSCAR --unitcell scelname --get-transf-mat  \n" <<
@@ -167,15 +167,15 @@ namespace CASM {
                   "    if so print the transformation matrix                             \n" <<
                   "  - Uses primitive cell for unitcell if none given                    \n" <<
                   "                                                                      \n" <<
-                  "  casm super --scelname scelname --unitcell scelname --get-transf-mat\n" <<
+                  "  casm super --scelnames scelname --unitcell scelname --get-transf-mat\n" <<
                   "  - Check if configuration lattice is a supercell of unit cell lattice.\n" <<
                   "    and print the transformation matrix                               \n" <<
                   "  - Uses primitive cell for unitcell if none given                    \n\n" <<
 
-                  "  casm super --duper --scelname scel1 [scel2 ...] --configname con1 [con2 ...]\n"
-                  "    --config [mylist ...] --transf-mat M1 [M2 ...]                    \n" <<
+                  "  casm super --duper --scelnames scel1 [scel2 ...] --confignames con1 [con2 ...]\n"
+                  "    --configs [mylist ...] --transf-mat M1 [M2 ...]                    \n" <<
                   "  - Makes the superdupercell of the lattices of all inputs            \n" <<
-                  "  - Using '--config' with no arguments is equivalent to '--config MASTER',\n" <<
+                  "  - Using '--configs' with no arguments is equivalent to '--configs MASTER',\n" <<
                   "    which uses the master config list                                 \n" <<
                   "  - Default applies prim point group ops to try to find minimum volume\n" <<
                   "    superdupercell, disable with '--fixed-orientation'                \n\n";
@@ -292,31 +292,31 @@ namespace CASM {
         }
       }
 
-      // collect supercells from --scelname
-      if(vm.count("scelname")) {
+      // collect supercells from --scelnames
+      if(vm.count("scelnames")) {
         for(auto it = scelname.begin(); it != scelname.end(); ++it) {
           lat[*it] = primclex.get_supercell(*it).get_real_super_lattice();
         }
       }
 
-      // collect configs from --configname
-      if(vm.count("configname")) {
+      // collect configs from --confignames
+      if(vm.count("confignames")) {
         for(auto it = configname.begin(); it != configname.end(); ++it) {
           config_lat[*it] = lat[*it] = primclex.configuration(*it).get_supercell().get_real_super_lattice();
         }
       }
 
-      // collect configs from lists via --config
-      if(vm.count("config")) {
+      // collect configs from lists via --configs
+      if(vm.count("configs")) {
 
-        // MASTER config list if '--config' only
+        // MASTER config list if '--configs' only
         if(config_path.size() == 0) {
           ConstConfigSelection selection(primclex);
           for(auto it = selection.selected_config_begin(); it != selection.selected_config_end(); ++it) {
             config_lat[it.name()] = lat[it.name()] = it->get_supercell().get_real_super_lattice();
           }
         }
-        // all input config list if '--config X Y ...'
+        // all input config list if '--configs X Y ...'
         else {
           for(auto c_it = config_path.begin(); c_it != config_path.end(); ++c_it) {
             if(c_it->string() == "MASTER") {
@@ -486,7 +486,7 @@ namespace CASM {
 
 
       // super lattice
-      if(vm.count("scelname")) {
+      if(vm.count("scelnames")) {
 
         Supercell &scel = primclex.get_supercell(scelname[0]);
 
@@ -510,7 +510,7 @@ namespace CASM {
 
       }
       // super structure
-      else if(vm.count("configname")) {
+      else if(vm.count("confignames")) {
 
         std::stringstream ss;
         const Configuration &con = primclex.configuration(configname[0]);
@@ -643,11 +643,11 @@ namespace CASM {
       if(vm.count("structure")) {
         super_lat = BasicStructure<Site>(abs_structfile).lattice();
       }
-      else if(vm.count("scelname")) {
+      else if(vm.count("scelnames")) {
         super_lat = primclex.get_supercell(scelname[0]).get_real_super_lattice();
       }
       else {
-        std::cout << "Error in 'casm super --get-transf-mat'. No --structure or --scelname given." << std::endl << std::endl;
+        std::cout << "Error in 'casm super --get-transf-mat'. No --structure or --scelnames given." << std::endl << std::endl;
         return 1;
       }
 

--- a/src/casm/app/update.cc
+++ b/src/casm/app/update.cc
@@ -2,6 +2,7 @@
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/ConfigIterator.hh"
 #include "casm/crystallography/jsonStruc.hh"
+#include "casm/clex/ConfigSelection.hh"
 #include "casm/clex/ConfigMapping.hh"
 #include "casm/app/casm_functions.hh"
 
@@ -26,14 +27,27 @@ namespace CASM {
       return m_vol_tolerance;
     }
 
+    double UpdateOption::min_va_frac() const {
+      return m_min_va_frac;
+    }
+
+    double UpdateOption::max_va_frac() const {
+      return m_max_va_frac;
+    }
+
     void UpdateOption::initialize() {
       add_help_suboption();
+      add_configlist_suboption("ALL");
 
       m_desc.add_options()
       ("cost-weight,w", po::value<double>(&m_lattice_weight)->default_value(0.5),
        "Adjusts cost function for mapping optimization (cost=w*lattice_deformation+(1-w)*basis_deformation)")
-      ("max-vol-change", po::value<double>(&m_vol_tolerance)->default_value(0.25),
-       "Adjusts range of SCEL volumes searched while mapping imported structure onto ideal crystal (only necessary if the presence of vacancies makes the volume ambiguous). Default is +/- 25% of relaxed_vol/prim_vol. Smaller values yield faster import, larger values may yield more accurate mapping.")
+      ("max-vol-change", po::value<double>(&m_vol_tolerance)->default_value(0.3),
+       "Adjusts range of SCEL volumes searched while mapping imported structure onto ideal crystal (only necessary if the presence of vacancies makes the volume ambiguous). Default is +/- 25% of relaxed_vol/prim_vol. Smaller values yield faster execution, larger values may yield more accurate mapping.")
+      ("max-va-frac", po::value<double>(&m_max_va_frac)->default_value(0.5),
+       "Places upper bound on the fraction of sites that are allowed to be vacant after relaxed structure is mapped onto the ideal crystal. Smaller values yield faster execution, larger values may yield more accurate mapping. Has no effect if supercell volume can be inferred from the number of atoms in the structure. Default value allows up to 50% of sites to be vacant.")
+      ("min-va-frac", po::value<double>(&m_min_va_frac)->default_value(0.),
+       "Places lower bound on the fraction of sites that are allowed to be vacant after relaxed structure is mapped onto the ideal crystal. Nonzero values may yield faster execution if updating configurations that are known to have a large number of vacancies, at potential sacrifice of mapping accuracy.  Has no effect if supercell volume can be inferred from the number of atoms in the structure. Default value allows as few as 0% of sites to be vacant.")
       ("force,f", "Force all configurations to update (otherwise, use timestamps to determine which configurations to update)")
       ("strict,s", "Attempt to import exact configuration.");
 
@@ -108,15 +122,23 @@ namespace CASM {
     PrimClex &primclex = make_primclex_if_not(args, uniq_primclex);
 
     ConfigMapper configmapper(primclex, lattice_weight, vol_tol, ConfigMapper::rotate | ConfigMapper::robust | (vm.count("strict") ? ConfigMapper::strict : 0), tol);
+    configmapper.set_min_va_frac(update_opt.min_va_frac());
+    configmapper.set_max_va_frac(update_opt.max_va_frac());
     std::cout << "Reading calculation data... " << std::endl << std::endl;
     std::vector<std::string> bad_config_report;
     std::vector<std::string> prop_names = primclex.settings().properties();
-    PrimClex::config_iterator it = primclex.config_begin();
+
     Index num_updated(0);
 
     std::map<Configuration *, std::map<Configuration *, Update_impl::Data> > update_map;
 
-    for(; it != primclex.config_end(); ++it) {
+    // Get configuration selection
+    ConfigSelection<false> selection(primclex, update_opt.selection_path());
+
+    auto it =  selection.selected_config_begin();
+    auto end = selection.selected_config_end();
+
+    for(; it != end; ++it) {
       /// Read properties.calc.json file containing externally calculated properties
       ///   location: casmroot/supercells/SCEL_NAME/CONFIG_ID/CURR_CALCTYPE/properties.calc.json
       ///

--- a/src/casm/clex/ChemicalReference.cc
+++ b/src/casm/clex/ChemicalReference.cc
@@ -63,8 +63,8 @@ namespace CASM {
       return N;
     }
 
-    bool _rank(const Eigen::MatrixXd &N,
-               double lin_alg_tol) {
+    int _rank(const Eigen::MatrixXd &N,
+              double lin_alg_tol) {
       auto Qr = N.transpose().fullPivHouseholderQr();
       Qr.setThreshold(lin_alg_tol);
       return Qr.rank();

--- a/src/casm/clex/ConfigIO.cc
+++ b/src/casm/clex/ConfigIO.cc
@@ -160,10 +160,11 @@ namespace CASM {
       "If one argument, accepts either: "
       "1) a cluster expansion name, for example 'corr(formation_energy)', and "
       "evaluates all basis functions, or "
-      "2) a range of indices of basis functions to evaluate, for example "
-      "'corr(ind1:ind2)'. "
-      "If two arguments, accepts cluster expansion name and a range of basis "
-      "functions to evaluate, for example 'corr(formation_energy,ind1:ind2)'.";
+      "2) an integer index or range of indices of basis functions to evaluate, "
+      "for example 'corr(6)', or 'corr(0:6)'. "
+      "If two arguments, accepts cluster expansion name and an integer index or "
+      "range of basis functions to evaluate, for example 'corr(formation_energy,6)' "
+      "or 'corr(formation_energy,0:6)'.";
 
     /// \brief Returns the atom fraction
     Eigen::VectorXd Corr::evaluate(const Configuration &config) const {
@@ -193,7 +194,8 @@ namespace CASM {
         return true;
       }
       else if(splt_vec.size() == 1) {
-        if(splt_vec[0].find(':') != std::string::npos) {
+        if((splt_vec[0].find_first_not_of("0123456789") == std::string::npos) ||
+           (splt_vec[0].find(':') != std::string::npos)) {
           _parse_index_expression(splt_vec[0]);
         }
         else {

--- a/src/casm/clex/Configuration.cc
+++ b/src/casm/clex/Configuration.cc
@@ -212,9 +212,14 @@ namespace CASM {
       }
       //Get RMS force:
       if(json.contains("relaxed_forces")) {
-        Eigen::MatrixXd forces;
-        from_json(forces, json["relaxed_forces"]);
-        parsed_props["rms_force"] = sqrt((forces.transpose() * forces).trace() / double(forces.rows()));
+        if(json["relaxed_forces"].size()) {
+          Eigen::MatrixXd forces;
+          from_json(forces, json["relaxed_forces"]);
+          parsed_props["rms_force"] = sqrt((forces.transpose() * forces).trace() / double(forces.rows()));
+        }
+        else {
+          parsed_props["rms_force"] = 0.;
+        }
       }
     }
     else

--- a/src/casm/completer/Handlers.cc
+++ b/src/casm/completer/Handlers.cc
@@ -221,23 +221,23 @@ namespace CASM {
       return selected_mode;
     }
 
-    void OptionHandlerBase::add_configlist_suboption() {
+    void OptionHandlerBase::add_configlist_suboption(const fs::path &_default) {
       m_desc.add_options()
       ("config,c",
-       po::value<fs::path>(&m_selection_path)->default_value("MASTER")->value_name(ArgHandler::path()),
-       "Only consider the selected configurations of the given selection file. "
-       "Standard selections are 'MASTER', 'CALCULATED', 'ALL', or 'NONE'. "
-       "If not specified, or 'MASTER' is given, the master list of your project will be used.");
+       po::value<fs::path>(&m_selection_path)->default_value(_default)->value_name(ArgHandler::path()),
+       (std::string("Only consider the selected configurations of the given selection file. "
+                    "Standard selections are 'MASTER', 'CALCULATED', 'ALL', or 'NONE'. "
+                    "If not specified, '") + _default.string() + std::string("' will be used.")).c_str());
       return;
     }
 
-    void OptionHandlerBase::add_configlists_suboption() {
+    void OptionHandlerBase::add_configlists_suboption(const fs::path &_default) {
       m_desc.add_options()
       ("configs,c",
-       po::value<std::vector<fs::path> >(&m_selection_paths)->default_value(std::vector<fs::path> {"MASTER"})->value_name(ArgHandler::path()),
-       "Only consider the selected configurations of the given selection files. "
-       "Standard selections are 'MASTER', 'CALCULATED', 'ALL', or 'NONE'. "
-       "If not specified, or 'MASTER' is given, the master list of your project will be used.");
+       po::value<std::vector<fs::path> >(&m_selection_paths)->default_value(std::vector<fs::path> {_default})->value_name(ArgHandler::path()),
+       (std::string("Only consider the selected configurations of the given selection file2. "
+                    "Standard selections are 'MASTER', 'CALCULATED', 'ALL', or 'NONE'. "
+                    "If not specified, '") + _default.string() + std::string("' will be used.")).c_str());
       return;
     }
 

--- a/src/casm/container/LinearAlgebra.cc
+++ b/src/casm/container/LinearAlgebra.cc
@@ -152,7 +152,7 @@ namespace CASM {
 
   /// \brief Get angle, in radians, between two vectors on range [0,pi]
   double angle(const Eigen::Ref<const Eigen::Vector3d> &a, const Eigen::Ref<const Eigen::Vector3d> &b) {
-    return acos(a.dot(b)) / (a.norm() * b.norm());
+    return acos(a.dot(b) / (a.norm() * b.norm()));
   }
 
   ///return signed angle, in radians, between -pi and pi that describe separation in direction of two vectors

--- a/src/casm/crystallography/Lattice.cc
+++ b/src/casm/crystallography/Lattice.cc
@@ -79,17 +79,18 @@ namespace CASM {
 
   //********************************************************************
   double Lattice::angle(Index i) const {
-    double t_a = m_lat_mat.col((i + 1) % 3).dot(m_lat_mat.col((i + 2) % 3)) / (length((i + 1) % 3) * length((i + 2) % 3));
+    //double t_a = m_lat_mat.col((i + 1) % 3).dot(m_lat_mat.col((i + 2) % 3)) / (length((i + 1) % 3) * length((i + 2) % 3));
     //Make sure that cos(angle) is between 0 and 1
-    if((t_a - 1.0) > 0.0) {
-      t_a = 1.0;
-    }
+    //if((t_a - 1.0) > 0.0) {
+    //t_a = 1.0;
+    //}
 
-    if((t_a + 1.0) < 0.0) {
-      t_a = -1.0;
-    }
+    //if((t_a + 1.0) < 0.0) {
+    //t_a = -1.0;
+    //}
 
-    return (180.0 / M_PI) * acos(t_a);
+    //return (180.0 / M_PI) * acos(t_a);
+    return (180.0 / M_PI) * CASM::angle(m_lat_mat.col((i + 1) % 3), m_lat_mat.col((i + 2) % 3));
   }
 
   //********************************************************************
@@ -495,22 +496,10 @@ namespace CASM {
   //********************************************************************
 
   double Lattice::max_voronoi_measure(const Eigen::Vector3d &pos, Eigen::Vector3d &lattice_trans)const {
+    Eigen::MatrixXd::Index maxv;
+    double maxproj = (voronoi_table() * pos).maxCoeff(&maxv);
 
-    double tproj(-1), maxproj(-1);
-    int maxv;
-    if(!voronoi_table.size()) {
-      generate_voronoi_table();
-    }
-
-    for(Index nv = 0; nv < voronoi_table.size(); nv++) {
-      tproj = pos.dot(voronoi_table[nv]);
-      if(tproj > maxproj) {
-        maxproj = tproj;
-        maxv = nv;
-      }
-    }
-
-    lattice_trans = (2.*floor(maxproj / 2. + (0.5 - TOL)) / voronoi_table[maxv].squaredNorm()) * voronoi_table[maxv];
+    lattice_trans = (2.*floor(maxproj / 2. + (0.5 - TOL / 2.)) / m_voronoi_table.row(maxv).squaredNorm()) * m_voronoi_table.row(maxv);
 
     return maxproj;
 
@@ -522,12 +511,10 @@ namespace CASM {
     int tnum = 0;
     double tproj = 0;
 
-    if(!voronoi_table.size()) {
-      generate_voronoi_table();
-    }
+    Eigen::MatrixXd const &vtable = voronoi_table();
 
-    for(Index nv = 0; nv < voronoi_table.size(); nv++) {
-      tproj = pos.dot(voronoi_table[nv]);
+    for(Index nv = 0; nv < vtable.size(); nv++) {
+      tproj = vtable.row(nv) * pos;
       if(almost_equal(tproj, 1.0)) {
         tnum++;
       }
@@ -541,50 +528,52 @@ namespace CASM {
   }
   //********************************************************************
 
-  void Lattice::generate_voronoi_table() const {
-    voronoi_table.clear();
+  void Lattice::_generate_voronoi_table() const {
     //There are no fewer than 12 points in the voronoi table
-    voronoi_table.reserve(12);
+    m_voronoi_table.resize(12, 3);
 
     m_inner_voronoi_radius = 1e20;
 
     Eigen::Vector3d tpoint;
     int i;
-
+    int nrows = 1;
     Lattice tlat_reduced(get_reduced_cell());
+
     //Count over all lattice vectors, face diagonals, and body diagonals
     //originating from origin;
     EigenCounter<Eigen::Vector3i > combo_count(Eigen::Vector3i(-1, -1, -1),
                                                Eigen::Vector3i(1, 1, 1),
                                                Eigen::Vector3i(1, 1, 1));
 
-    //std::cout << "For angles " << angles[0] << ", " << angles[1] << ", " << angles[2] << ", Voronoi table is: \n";
+
     //For each linear combination, check to see if it is on a face, edge, or vertex of the voronoi cell
     for(; combo_count.valid(); ++combo_count) {
       if(combo_count().isZero()) continue;
       //A linear combination does not fall on the voronoi boundary if the angle between
-      //any two of the vectors forming that combination are obtuse
+      //any two of the vectors forming that combination are acute
       for(i = 0; i < 3; i++) {
-        if((combo_count[(i + 1) % 3] && combo_count[(i + 2) % 3])
-           && std::abs(90.0 * abs(combo_count[(i + 1) % 3] - combo_count[(i + 2) % 3]) - angle(i)) + TOL < 90) {
+        if(combo_count[(i + 1) % 3] == 0 || combo_count[(i + 2) % 3] == 0)
+          continue;
+        if((180. / M_PI)*CASM::angle(combo_count[(i + 1) % 3]*tlat_reduced[(i + 1) % 3], combo_count[(i + 2) % 3]*tlat_reduced[(i + 2) % 3]) + TOL < 90.) {
           break;
         }
       }
 
       if(i == 3) {
+        if(nrows > m_voronoi_table.rows())
+          m_voronoi_table.conservativeResize(nrows, Eigen::NoChange);
+
         tpoint = tlat_reduced.lat_column_mat() * combo_count().cast<double>();
 
         double t_rad = tpoint.norm();
         if((t_rad / 2.) < m_inner_voronoi_radius)
           m_inner_voronoi_radius = t_rad / 2.;
 
-        tpoint *= (2. / (t_rad * t_rad));
-        voronoi_table.push_back(tpoint);
-        //std::cout << voronoi_table.back();
+        m_voronoi_table.row(nrows - 1) = (2. / (t_rad * t_rad)) * tpoint;
+        nrows++;
       }
 
     }
-
     return;
   }
 

--- a/src/ccasm/SConscript
+++ b/src/ccasm/SConscript
@@ -6,7 +6,14 @@ Import('env')
 # get source files
 ccasm_lib_src = ['api.cc']
 
+#include path
+candidates = [
+  env['INCDIR'],
+  env.include_path(env['BOOST_PREFIX'], 'boost')
+]
+cpppath = [x for x in candidates if x is not None]
+
 ccasm_lib_sobj = env.SharedObject(ccasm_lib_src,
-                                  CPPPATH=env['INCDIR'])
+                                  CPPPATH=cpppath)
 env['COMPILE_TARGETS'] = env['COMPILE_TARGETS'] + ccasm_lib_sobj
 env['CCASM_SOBJ'] = env['CCASM_SOBJ'] + ccasm_lib_sobj

--- a/tests/unit/SConscript
+++ b/tests/unit/SConscript
@@ -68,7 +68,7 @@ for i, src_name in enumerate(test_name):
   
   # individual tests that need common linking options
   if src_name[:-5] in ["Structure", "BasicStructure", "ConfigIODictionary", "App", 
-                       "ConfigIO", "PrimClex", "ChemicalReference", "NeighborList",
+                       "ConfigIO", "Coordinate", "PrimClex", "ChemicalReference", "NeighborList",
                        "Clusterography", "SupercellEnumerator", "Niggli",
                        "settings"]:
     test = lenv.Program(os.path.join(lenv['UNIT_TEST_BINDIR'], src_name), 

--- a/tests/unit/crystallography/Coordinate_test.cpp
+++ b/tests/unit/crystallography/Coordinate_test.cpp
@@ -218,7 +218,7 @@ void coordinate_periodicity_test() {
       Coordinate coord2(point_count(), lat, FRAC);
       // optimality of robust_min_dist
       BOOST_CHECK(coord1.robust_min_dist(coord2) < (coord1.min_dist(coord2) + tol));
-      //std::cout << "A: " << coord1.robust_min_dist(coord2)<< ";   B: " << coord1.min_dist(coord2)<< "\n";
+
       // commutativity of robust_min_dist
       BOOST_CHECK(almost_equal(coord2.robust_min_dist(coord1), coord1.robust_min_dist(coord2), tol));
       Coordinate trans(lat);
@@ -228,6 +228,21 @@ void coordinate_periodicity_test() {
       BOOST_CHECK(almost_equal(coord2.robust_min_dist(coord1), coord1.robust_min_dist(coord2, trans), tol));
 
       BOOST_CHECK(almost_equal(trans.const_cart().norm(), coord2.robust_min_dist(coord1)));
+    }
+
+    Eigen::MatrixXd const &vtable = lat.voronoi_table();
+    Coordinate zero_coord(Eigen::Vector3d::Zero(), lat, FRAC);
+
+    // check robustness of edge cases
+    for(Index i = 0; i < vtable.rows(); i++) {
+      {
+        Coordinate coord2((1 + tol / 2.)*vtable.row(i).transpose() / vtable.row(i).squaredNorm(), lat, CART);
+        BOOST_CHECK(coord2.robust_min_dist(zero_coord) <= coord2.const_cart().norm());
+      }
+      {
+        Coordinate coord2((1 - tol / 2.)*vtable.row(i).transpose() / vtable.row(i).squaredNorm(), lat, CART);
+        BOOST_CHECK(almost_equal(coord2.robust_min_dist(zero_coord), coord2.const_cart().norm(), tol / 2));
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes issue #13, which prevented import or mapping of a structure with no basis atoms (corresponding to all Va).  This was caused by a number of instances of undefined division (0./0.), as well as unguarded access of the first element of an array (which may be empty).
