### PR TITLE
Allow fault-tolerant behavior in `casm select`

### DIFF
--- a/include/casm/casm_io/DataFormatterTools.hh
+++ b/include/casm/casm_io/DataFormatterTools.hh
@@ -57,9 +57,11 @@ namespace CASM {
     bool parse_args(const std::string &_args) override;
 
     void inject(const DataObject &_data_obj, DataStream &_stream, Index pass_index) const override {
-      _stream << _evaluate(_data_obj);
       if(!validate(_data_obj)) {
-        _stream << DataStream::failbit;
+        _stream << DataStream::failbit << ValueType();
+      }
+      else {
+        _stream << _evaluate(_data_obj);
       }
     }
 
@@ -738,9 +740,10 @@ namespace CASM {
     ///
     /// - sets DataStream::failbit if validation fails
     virtual void inject(const DataObject &_data_obj, DataStream &_stream, Index pass_index = 0) const override {
-      _stream << this->evaluate(_data_obj);
       if(!this->validate(_data_obj))
-        _stream << DataStream::failbit;
+        _stream << DataStream::failbit << ValueType();
+      else
+        _stream << this->evaluate(_data_obj);
     }
 
     /// \brief Default implementation prints each element in a column, via operator<<
@@ -890,6 +893,7 @@ namespace CASM {
 
     /// \brief Access methods for Container
     typedef typename ContainerTraits<Container>::Access Access;
+    typedef typename ContainerTraits<Container>::value_type ValueType;
 
 
     /// \brief Constructor
@@ -950,10 +954,16 @@ namespace CASM {
 
       Container val = this->evaluate(_data_obj);
       auto it(_index_rules().cbegin()), end_it(_index_rules().cend());
-      if(!this->validate(_data_obj))
+      if(!this->validate(_data_obj)) {
         _stream << DataStream::failbit;
-      for(; it != end_it; ++it) {
-        _stream << Access::at(val, (*it)[0]);
+        for(; it != end_it; ++it) {
+          _stream << ValueType();
+        }
+      }
+      else {
+        for(; it != end_it; ++it) {
+          _stream << Access::at(val, (*it)[0]);
+        }
       }
     }
 

--- a/include/casm/casm_io/DataStream.hh
+++ b/include/casm/casm_io/DataStream.hh
@@ -15,7 +15,9 @@ namespace CASM {
 
     static DataStream &endl(DataStream &_strm) {
       return _strm.newline();
-    };
+    }
+
+    static std::function<DataStream &(DataStream &_strm)> failure(std::string const &_msg);
 
     DataStream(DataStreamTraits _traits = none) :
       m_traits(_traits) {}
@@ -52,6 +54,10 @@ namespace CASM {
       return F(*this);
     }
 
+    DataStream &operator<<(const std::function<DataStream & (DataStream &)> &F) {
+      return F(*this);
+    }
+
     virtual DataStream &newline() {
       return *this;
     }
@@ -67,8 +73,18 @@ namespace CASM {
 
     void clear_fail() {
       m_traits &= ~failbit;
+      m_err_msg.clear();
     }
+
+    std::string const &err_msg() const {
+      return m_err_msg;
+    }
+
   protected:
+
+    void _set_err_msg(std::string const &_msg) {
+      m_err_msg = _msg;
+    }
 
     bool _skipfail() {
       return m_traits & skipfail;
@@ -76,6 +92,7 @@ namespace CASM {
 
   private:
     int m_traits;
+    std::string m_err_msg;
   };
 
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -125,6 +142,15 @@ namespace CASM {
     int m_count;
 
   };
+
+  inline
+  std::function<DataStream &(DataStream &_strm)> DataStream::failure(std::string const &_msg) {
+    return [&_msg](DataStream & _stream)->DataStream & {
+      _stream << failbit;
+      _stream._set_err_msg(_msg);
+      return _stream;
+    };
+  }
 
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/casm/casm_io/DataStream.hh
+++ b/include/casm/casm_io/DataStream.hh
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <functional>
 namespace CASM {
 
   class DataStream {

--- a/include/casm/casm_io/EigenDataStream.hh
+++ b/include/casm/casm_io/EigenDataStream.hh
@@ -11,10 +11,10 @@ namespace CASM {
       if(m_col == m_matrix.cols()) {
         if(m_row > 0 || m_matrix.rows() != 1)
           throw std::runtime_error("Attempting to stream non-rectangular data to Eigen::MatrixXd using MatrixXdDataStream, at row=" + std::to_string(m_row) + ", col=" + std::to_string(m_row) + "\n");
-        m_matrix = (Eigen::MatrixXd(m_matrix.rows(), m_col + 1) << m_matrix, 0.0).finished();
+        m_matrix.conservativeResize(Eigen::NoChange, m_col + 1);
       }
       if(m_row == m_matrix.rows()) {
-        m_matrix = (Eigen::MatrixXd(m_row + 1, m_matrix.cols()) << m_matrix, Eigen::MatrixXd::Zero(1, m_matrix.cols())).finished();
+        m_matrix.conservativeResize(m_row + 1, Eigen::NoChange);
       }
       m_matrix(m_row, m_col++) = _d;
       return *this;


### PR DESCRIPTION
This pull requests applies small changes to the way that selection criteria are applied to a config selection and how errors are handled.  Specifically, configurations are ignored if there is insufficient data about a configuration to apply the selection criteria to it.

For example, if configuration `SCEL1_1_1_1_0_0_0/1` has not been calculated but is selected in selection `myselect`, the following are true:
`casm select --set-on "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` remaining selected in `outselect`

`casm select --set-off "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` remaining selected in `outselect`

`casm select --set "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` not being selected in `outselect`

Additionally, if configuration `SCEL1_1_1_1_0_0_0/1` has not been calculated but is UNselected in selection `myselect`, the following are true:
`casm select --set-on "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` remaining unselected in `outselect`

`casm select --set-off "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` remaining unselected in `outselect`

`casm select --set "lt(formation_energy, 0.01)" -c myselect -o outselect` will result in `SCEL1_1_1_1_0_0_0/1` not being selected in `outselect`

I don't think there is an ideal policy to apply in the case where a selection criterion requires unknown information, but I believe this avoids users needing to construct arcane queries just to get `casm select` to execute without returning an error.  Please chime in if you think there is a better policy to use in these situations.
