### PR TITLE
Fixed sign error in LatticeMap::calc_strain_cost()

### DIFF
--- a/src/casm/crystallography/LatticeMap.cc
+++ b/src/casm/crystallography/LatticeMap.cc
@@ -120,7 +120,7 @@ namespace CASM {
     Eigen::Matrix3d cache = 0.5 * (F.transpose() * F / pow(std::abs(F.determinant()), 2.0 / 3.0) - Eigen::Matrix3d::Identity(3, 3));
 
     // geometric factor: (3*V/(4*pi))^(2/3)/3 = V^(2/3)/7.795554179
-    return std::pow(relaxed_atomic_vol, 2.0 / 3.0) * cache.squaredNorm() / 7.795554179;
+    return std::pow(std::abs(relaxed_atomic_vol), 2.0 / 3.0) * cache.squaredNorm() / 7.795554179;
   }
   //*******************************************************************************************
   double LatticeMap::_calc_strain_cost() const {


### PR DESCRIPTION
When passed a negative signed volume, `LatticeMap::calc_strain_cost()` would return `nan`. This fix ensures that the unsigned volume is always used.