### PR TITLE
MAGMOM tag fix

### DIFF
--- a/python/vasp/vasp/io/incar.py
+++ b/python/vasp/vasp/io/incar.py
@@ -160,8 +160,6 @@ class Incar:
                           self.tags[key].append(species[name].tags[key])
                           break
                     else:
-                        #for site in pos[alias]:
-                        #    self.tags[key].append( species[site.occupant].tags[key] )
                         self.tags[key].append( str(len(pos[alias])) + "*" + str(species[pos[alias][0].occupant].tags[key]) )
 
     def write(self, filename):

--- a/python/vasp/vasp/io/incar.py
+++ b/python/vasp/vasp/io/incar.py
@@ -91,7 +91,11 @@ class Incar:
                     temp = []
                     for value in self.tags[tag].split():
                         try:
-                            temp.append(float(value))
+                            item=value.split('*')
+                            if len(item)==1:
+                                temp.append(float(value))
+                            else:
+                                temp.append(str(item[0])+'*'+str(float(item[1])))
                         except ValueError:
                             raise IncarError("Could not convert '" + tag + "' : '" + self.tags[tag] + "' to float list")
                     self.tags[tag] = temp
@@ -156,8 +160,9 @@ class Incar:
                           self.tags[key].append(species[name].tags[key])
                           break
                     else:
-                        for site in pos[alias]:
-                            self.tags[key].append( species[site.occupant].tags[key] )
+                        #for site in pos[alias]:
+                        #    self.tags[key].append( species[site.occupant].tags[key] )
+                        self.tags[key].append( str(len(pos[alias])) + "*" + str(species[pos[alias][0].occupant].tags[key]) )
 
     def write(self, filename):
         try:


### PR DESCRIPTION
This changes the way that the tags in VASP_SITEF_LIST are added to an INCAR from the SPECIES file. This is coupled with the way that the type of the tag is verified. Results in MAGMOM looking like:
```18*0 32*0 16*2```
instead of 
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0... 0 0 0 0 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2