### PR TITLE
Vasp Error Handler Changes

### DIFF
--- a/python/vasp/vasp/vasp.py
+++ b/python/vasp/vasp/vasp.py
@@ -751,9 +751,7 @@ def run(jobdir = None, stdout = "std.out", stderr = "std.err", npar=None, ncore=
 
         if time.time() - last_check > err_check_time:
             last_check = time.time()
-            err = crash_check(jobdir, os.path.join(jobdir, stdout), err_types)
-            if err is None:
-                err = error_check(jobdir, os.path.join(jobdir, stdout), err_types)
+            err = error_check(jobdir, os.path.join(jobdir, stdout), err_types)
             if err != None:
                 # FreezeErrors are fatal and usually not helped with STOPCAR
                 if "FreezeError" in err.keys():


### PR DESCRIPTION
1. SubspaceMatrixError had two bugs:
    * "LREAD" vs "LREAL" (only the latter is actually an INCAR tag!)
    * get_incar_tag('LREAL') returns a string, not a bool, so you need to do `=='False'`
2. Added some additional error handlers! I've learned about SO MANY WAYS VASP CAN FAIL
3. Changed error checking so that a running job is *first* checked for a crash, then for an error (crashes are higher priority than errors)