### PR TITLE
MonteDriver fix possibly related to #51

### DIFF
--- a/include/casm/monte_carlo/MonteDriver.hh
+++ b/include/casm/monte_carlo/MonteDriver.hh
@@ -187,7 +187,10 @@ namespace CASM {
         ConfigDoF configdof = m_mc.configdof();
         from_json(configdof, jsonParser(m_dir.final_state_json(start_i - 1)));
 
-        m_mc.set_configdof(configdof, std::string("Using: ") + m_dir.final_state_json(start_i - 1).string());
+        m_mc.set_state(
+          m_conditions_list[start_i],
+          configdof,
+          std::string("Using: ") + m_dir.final_state_json(start_i - 1).string());
       }
     }
 
@@ -196,13 +199,16 @@ namespace CASM {
       if(!m_settings.dependent_runs()) {
         m_mc.set_state(m_conditions_list[i], m_settings);
       }
-      else {
+      else if(i != start_i) {
+
         m_mc.set_conditions(m_conditions_list[i]);
 
         m_log.custom("Continue with existing DoF");
         m_log << std::endl;
       }
+
       single_run(i);
+
       m_log << std::endl;
     }
 


### PR DESCRIPTION
When restarting Monte Carlo, using `"dependent_runs": true`, set conditions and configdof at the same time. This prevents a crash using canonical MC, and might be related to issue #51 