### PR TITLE
add ConfigEnumRandomOccupations standard enumerator

### DIFF
--- a/include/casm/clex/ConfigEnumRandomOccupations.hh
+++ b/include/casm/clex/ConfigEnumRandomOccupations.hh
@@ -1,0 +1,65 @@
+#ifndef CASM_ConfigEnumRandomOccupations
+#define CASM_ConfigEnumRandomOccupations
+
+#include "casm/container/Counter.hh"
+#include "casm/container/InputEnumerator.hh"
+#include "casm/clex/Configuration.hh"
+#include "casm/misc/cloneable_ptr.hh"
+
+extern "C" {
+  CASM::EnumInterfaceBase *make_ConfigEnumRandomOccupations_interface();
+}
+
+class MTRand;
+
+namespace CASM {
+
+  /** \defgroup ConfigEnumGroup Configuration Enumerators
+   *  \ingroup Configuration
+   *  \ingroup Enumerator
+   *  \brief Enumerates Configuration
+   *  @{
+  */
+
+  /// \brief Enumerate n random occupations in a particular Supercell
+  ///
+  class ConfigEnumRandomOccupations : public InputEnumeratorBase<Configuration> {
+
+    // -- Required members -------------------
+
+  public:
+
+    /// \brief Construct with a Supercell, using all permutations
+    ConfigEnumRandomOccupations(
+      Supercell &_scel,
+      Index _n_config,
+      MTRand &_mtrand);
+
+    std::string name() const override {
+      return enumerator_name;
+    }
+
+    static const std::string enumerator_name;
+    static const std::string interface_help;
+    static int run(PrimClex &primclex, const jsonParser &kwargs, const Completer::EnumOption &enum_opt);
+
+  private:
+
+
+    /// Implements increment
+    void increment() override;
+
+    // -- Unique -------------------
+
+    void randomize();
+
+    Index m_n_config;
+    MTRand *m_mtrand;
+    Array<int> m_max_allowed;
+    notstd::cloneable_ptr<Configuration> m_current;
+  };
+
+  /** @}*/
+}
+
+#endif

--- a/include/casm/container/Enumerator.hh
+++ b/include/casm/container/Enumerator.hh
@@ -495,8 +495,19 @@ namespace CASM {
     std::vector<std::string> filter_expr);
 
   /// \brief Standardizes insertion from enumerators that construct configurations
-  template<typename LatticeIterator, typename ConfigEnumConstructor>
+  template<typename ScelIterator, typename ConfigEnumConstructor>
   int insert_configs(
+    std::string method,
+    PrimClex &primclex,
+    ScelIterator begin,
+    ScelIterator end,
+    ConfigEnumConstructor f,
+    std::vector<std::string> filter_expr,
+    bool primitive_only);
+
+  /// \brief Standardizes insertion from enumerators that construct configurations
+  template<typename LatticeIterator, typename ConfigEnumConstructor>
+  int insert_configs_via_lattice_enum(
     std::string method,
     PrimClex &primclex,
     LatticeIterator begin,

--- a/include/casm/container/Enumerator_impl.hh
+++ b/include/casm/container/Enumerator_impl.hh
@@ -87,6 +87,88 @@ namespace CASM {
   ///
   /// \param method Enumerator name, printed to screen
   /// \param primclex PrimClex to add Configurations to
+  /// \param begin,end Iterators over Supercell
+  /// \param f A function that signature `std::unique_ptr<EnumMethod> f(Supercell&)`
+  ///        that returns a std::unique_ptr owning a Configuration enumerator
+  /// \param filter_expr An vector of Configuration filtering expressions. No filtering if empty.
+  /// \param primitive_only If true, only insert primitive Configurations; else
+  ///        both primitive and non-primitive.
+  ///
+  /// \returns 0 if success, ERR_INVALID_ARG if filter_expr cannot be parsed
+  ///
+  template<typename ScelIterator, typename ConfigEnumConstructor>
+  int insert_configs(
+    std::string method,
+    PrimClex &primclex,
+    ScelIterator begin,
+    ScelIterator end,
+    ConfigEnumConstructor f,
+    std::vector<std::string> filter_expr,
+    bool primitive_only) {
+
+    Log &log = primclex.log();
+
+    Index Ninit = std::distance(primclex.config_begin(), primclex.config_end());
+    log << "# configurations in this project: " << Ninit << "\n" << std::endl;
+
+    log.begin(method);
+
+    for(auto scel_it = begin; scel_it != end; ++scel_it) {
+      Supercell &scel = *scel_it;
+      log << "Enumerate configurations for " << scel.get_name() << " ...  " << std::flush;
+
+      auto enumerator_ptr = f(scel);
+      auto &enumerator = *enumerator_ptr;
+      Index num_before = scel.get_config_list().size();
+      if(!filter_expr.empty()) {
+        try {
+          auto it = filter_begin(
+                      enumerator.begin(),
+                      enumerator.end(),
+                      filter_expr,
+                      primclex.settings().query_handler<Configuration>().dict());
+          auto end = filter_end(enumerator.end());
+          for(; it != end; ++it) {
+            it->insert(primitive_only);
+          }
+        }
+        catch(std::exception &e) {
+          primclex.err_log() << "Cannot filter configurations using the expression provided: \n" << e.what() << "\nExiting...\n";
+          return ERR_INVALID_ARG;
+        }
+      }
+      else {
+        auto it = enumerator.begin();
+        auto end = enumerator.end();
+        for(; it != end; ++it) {
+          it->insert(primitive_only);
+        }
+      }
+
+      log << (scel.get_config_list().size() - num_before) << " configs." << std::endl;
+    }
+    log << "  DONE." << std::endl << std::endl;
+
+    Index Nfinal = std::distance(primclex.config_begin(), primclex.config_end());
+
+    log << "# new configurations: " << Nfinal - Ninit << "\n";
+    log << "# configurations in this project: " << Nfinal << "\n" << std::endl;
+
+    log << "Write SCEL..." << std::endl;
+    primclex.print_supercells();
+    log << "  DONE" << std::endl << std::endl;
+
+    log << "Writing config_list..." << std::endl;
+    primclex.write_config_list();
+    log << "  DONE" << std::endl;
+
+    return 0;
+  }
+
+  /// \brief Standardizes insertion from enumerators that construct configurations
+  ///
+  /// \param method Enumerator name, printed to screen
+  /// \param primclex PrimClex to add Configurations to
   /// \param begin,end Iterators over lattice (need not be canonical), to be used for Supercell
   /// \param f A function that signature `std::unique_ptr<EnumMethod> f(Supercell&)`
   ///        that returns a std::unique_ptr owning a Configuration enumerator
@@ -97,7 +179,7 @@ namespace CASM {
   /// \returns 0 if success, ERR_INVALID_ARG if filter_expr cannot be parsed
   ///
   template<typename LatticeIterator, typename ConfigEnumConstructor>
-  int insert_configs(
+  int insert_configs_via_lattice_enum(
     std::string method,
     PrimClex &primclex,
     LatticeIterator begin,

--- a/src/casm/app/EnumeratorHandler.cc
+++ b/src/casm/app/EnumeratorHandler.cc
@@ -1,6 +1,7 @@
 #include "casm/app/EnumeratorHandler_impl.hh"
 #include "casm/clex/ScelEnum.hh"
 #include "casm/clex/ConfigEnumAllOccupations.hh"
+#include "casm/clex/ConfigEnumRandomOccupations.hh"
 #include "casm/clex/SuperConfigEnum.hh"
 
 namespace CASM {
@@ -12,7 +13,8 @@ namespace CASM {
     m_enumerator.insert(
       EnumInterface<ScelEnum>(),
       EnumInterface<ConfigEnumAllOccupations>(),
-      EnumInterface<SuperConfigEnum>()
+      EnumInterface<SuperConfigEnum>(),
+      EnumInterface<ConfigEnumRandomOccupations>()
     );
 
     load_enumerator_plugins(

--- a/src/casm/app/status.cc
+++ b/src/casm/app/status.cc
@@ -349,6 +349,36 @@ Instructions for fitting ECI:                                          \n\n\
     }
   }
 
+  void print_details(const CommandArgs &args, const PrimClex &primclex) {
+    int tot_gen = 0;
+    int tot_calc = 0;
+    int tot_sel = 0;
+
+    //args.log << std::setw(6) << " " << " " << std::setw(30) << " " << "     " << "#CONFIGS" << std::endl;
+    args.log << std::setw(6) << "INDEX" << " " << std::setw(30) << "SUPERCELL" << "     " << "#CONFIGS G / C / S" << std::endl;
+    args.log << "---------------------------------------------------------------------------" << std::endl;
+    for(int i = 0; i < primclex.get_supercell_list().size(); i++) {
+      int gen = primclex.get_supercell(i).get_config_list().size();
+      int calc = 0, sel = 0;
+      const Supercell &scel = primclex.get_supercell(i);
+      for(int j = 0; j < scel.get_config_list().size(); j++) {
+        if(scel.get_config(j).selected()) {
+          sel++;
+        }
+        if(scel.get_config(j).calc_properties().contains("relaxed_energy")) {
+          calc++;
+        }
+      }
+      tot_gen += gen;
+      tot_calc += calc;
+      tot_sel += sel;
+      args.log << std::setw(6) << i << " " << std::setw(30) << primclex.get_supercell(i).get_name() << "     " << gen << " / " << calc << " / " << sel << std::endl;
+    }
+    args.log << "---------------------------------------------------------------------------" << std::endl;
+    args.log << std::setw(6) << " " << " " << std::setw(30) << "TOTAL" << "     " << tot_gen << " / " << tot_calc << " / " << tot_sel << std::endl;
+    args.log << "\nG:Generated, C:Calculated, S:Selected" << std::endl << std::endl;
+  }
+
   int status_command(const CommandArgs &args) {
 
     po::variables_map vm;
@@ -574,6 +604,13 @@ Instructions for fitting ECI:                                          \n\n\
         args.log << "For next steps, run 'casm status -n'\n\n";
       }
 
+      if(vm.count("details")) {
+        print_details(args, primclex);
+      }
+      else {
+        args.log << "For the number of configurations generated, calculated,\n and selected by supercell, run 'casm status -d'\n\n";
+      }
+
       return 0;
     }
 
@@ -596,33 +633,7 @@ Instructions for fitting ECI:                                          \n\n\
     args.log << "- Number of configurations calculated: " << tot_calc << " / " << tot_gen << " generated (Update with 'casm update')\n\n";
 
     if(vm.count("details")) {
-      //args.log << std::setw(6) << " " << " " << std::setw(30) << " " << "     " << "#CONFIGS" << std::endl;
-      args.log << std::setw(6) << "INDEX" << " " << std::setw(30) << "SUPERCELL" << "     " << "#CONFIGS G / C / S" << std::endl;
-      args.log << "---------------------------------------------------------------------------" << std::endl;
-      for(int i = 0; i < primclex.get_supercell_list().size(); i++) {
-        int tot_gen = 0;
-        int tot_calc = 0;
-        int tot_sel = 0;
-
-        int gen = primclex.get_supercell(i).get_config_list().size();
-        int calc = 0, sel = 0;
-        const Supercell &scel = primclex.get_supercell(i);
-        for(int j = 0; j < scel.get_config_list().size(); j++) {
-          if(scel.get_config(j).selected()) {
-            sel++;
-          }
-          if(scel.get_config(j).calc_properties().contains("relaxed_energy")) {
-            calc++;
-          }
-        }
-        tot_gen += gen;
-        tot_calc += calc;
-        tot_sel += sel;
-        args.log << std::setw(6) << i << " " << std::setw(30) << primclex.get_supercell(i).get_name() << "     " << gen << " / " << calc << " / " << sel << std::endl;
-      }
-      args.log << "---------------------------------------------------------------------------" << std::endl;
-      args.log << std::setw(6) << " " << " " << std::setw(30) << "TOTAL" << "     " << tot_gen << " / " << tot_calc << " / " << tot_sel << std::endl;
-      args.log << "\nG:Generated, C:Calculated, S:Selected" << std::endl << std::endl;
+      print_details(args, primclex);
     }
     else {
       args.log << "For the number of configurations generated, calculated,\n and selected by supercell, run 'casm status -d'\n\n";

--- a/src/casm/clex/ConfigEnumRandomOccupations.cc
+++ b/src/casm/clex/ConfigEnumRandomOccupations.cc
@@ -29,14 +29,16 @@ namespace CASM {
 
     "  primitive_only: bool (default=true)\n"
     "    If true, only the primitive form of a configuration is saved in the      \n"
-    "    otherwise, both primitive and non-primitive configurations are saved.    \n\n"
+    "    configuration list. Otherwise, both primitive and non-primitive          \n"
+    "    configurations are saved. \n\n"
 
     "  filter: string (optional, default=None)\n"
     "    A query command to use to filter which Configurations are kept.          \n\n"
 
     "  Examples:\n"
     "    To enumerate 200 random occupations in supercells up to and including size 4:\n"
-    "      casm enum --method ConfigEnumRandomOccupations -i '{\"supercells\": {\"max\": 4}, \"n_config\": 200}' \n"
+    "      casm enum --method ConfigEnumRandomOccupations -i \n"
+    "        '{\"supercell\":{\"max\":4}, \"n_config\": 200}' \n"
     "\n"
     "    To enumerate 200 random occupations in all existing supercells:\n"
     "      casm enum --method ConfigEnumRandomOccupations -i '{\"n_config\": 200}' \n"

--- a/src/casm/clex/ConfigEnumRandomOccupations.cc
+++ b/src/casm/clex/ConfigEnumRandomOccupations.cc
@@ -1,0 +1,150 @@
+#include "casm/clex/ConfigEnumRandomOccupations.hh"
+#include "casm/container/Enumerator_impl.hh"
+#include "casm/clex/ScelEnum.hh"
+#include "casm/external/MersenneTwister/MersenneTwister.h"
+#include "casm/clex/FilteredConfigIterator.hh"
+
+extern "C" {
+  CASM::EnumInterfaceBase *make_ConfigEnumRandomOccupations_interface() {
+    return new CASM::EnumInterface<CASM::ConfigEnumRandomOccupations>();
+  }
+}
+
+namespace CASM {
+
+  const std::string ConfigEnumRandomOccupations::enumerator_name = "ConfigEnumRandomOccupations";
+
+  const std::string ConfigEnumRandomOccupations::interface_help =
+    "ConfigEnumRandomOccupations: \n\n"
+
+    "  supercells: ScelEnum JSON settings (default='{\"existing_only\"=true}')\n"
+    "    Indicate supercells to enumerate all occupational configurations in. May \n"
+    "    be a JSON array of supercell names, or a JSON object specifying          \n"
+    "    supercells in terms of size and unit cell. By default, all existing      \n"
+    "    supercells are used. See 'ScelEnum' description for details.         \n\n"
+
+    "  n_config: integer (optional, default=100) \n"
+    "    How many random configurations to generate. Includes duplicate and pre-\n"
+    "    existing configurations.                                                 \n\n"
+
+    "  primitive_only: bool (default=true)\n"
+    "    If true, only the primitive form of a configuration is saved in the      \n"
+    "    otherwise, both primitive and non-primitive configurations are saved.    \n\n"
+
+    "  filter: string (optional, default=None)\n"
+    "    A query command to use to filter which Configurations are kept.          \n\n"
+
+    "  Examples:\n"
+    "    To enumerate 200 random occupations in supercells up to and including size 4:\n"
+    "      casm enum --method ConfigEnumRandomOccupations -i '{\"supercells\": {\"max\": 4}, \"n_config\": 200}' \n"
+    "\n"
+    "    To enumerate 200 random occupations in all existing supercells:\n"
+    "      casm enum --method ConfigEnumRandomOccupations -i '{\"n_config\": 200}' \n"
+    "\n"
+    "    To enumerate 100 random occupations in all existing supercells:\n"
+    "      casm enum --method ConfigEnumRandomOccupations' \n"
+    "\n"
+    "    To enumerate 200 random occupations in particular supercells:\n"
+    "      casm enum --method ConfigEnumRandomOccupations -i \n"
+    "      '{ \n"
+    "        \"supercells\": { \n"
+    "          \"name\": [\n"
+    "            \"SCEL1_1_1_1_0_0_0\",\n"
+    "            \"SCEL2_1_2_1_0_0_0\",\n"
+    "            \"SCEL4_1_4_1_0_0_0\"\n"
+    "          ]\n"
+    "        }, \n"
+    "        \"n_config\": 200\n"
+    "      }' \n\n";
+
+  int ConfigEnumRandomOccupations::run(
+    PrimClex &primclex,
+    const jsonParser &_kwargs,
+    const Completer::EnumOption &enum_opt) {
+
+    std::unique_ptr<ScelEnum> scel_enum = make_enumerator_scel_enum(primclex, _kwargs, enum_opt);
+    std::vector<std::string> filter_expr = make_enumerator_filter_expr(_kwargs, enum_opt);
+    MTRand mtrand;
+
+    Index n_config;
+    _kwargs.get_else<Index>(n_config, "n_config", 100);
+
+    bool primitive_only = true;
+    _kwargs.get_if(primitive_only, "primitive_only");
+
+
+    auto lambda = [&](Supercell & scel) {
+      return notstd::make_unique<ConfigEnumRandomOccupations>(scel, n_config, mtrand);
+    };
+
+    int returncode = insert_configs(
+                       enumerator_name,
+                       primclex,
+                       scel_enum->begin(),
+                       scel_enum->end(),
+                       lambda,
+                       filter_expr,
+                       primitive_only);
+
+    return returncode;
+  }
+
+  /// \brief Constructor
+  ///
+  /// \param _initial,_final Initial and final configurations to interpolate between
+  /// \param _size The total number of configurations to enumerate, including
+  ///              the initial and final configurations
+  ///
+  /// - The `final` configuration is *not* pointed at by the end iterator,
+  ///   which points past-the-final element, as is typical
+  /// - `_size` will be equal to \code std::distance(this->begin(), this->end()) \endcode
+  ConfigEnumRandomOccupations::ConfigEnumRandomOccupations(
+    Supercell &_scel,
+    Index _n_config,
+    MTRand &_mtrand):
+    m_n_config(_n_config),
+    m_max_allowed(_scel.max_allowed_occupation()),
+    m_mtrand(&_mtrand) {
+
+    if(m_n_config < 0) {
+      throw std::runtime_error("Error in ConfigEnumRandomOccupations: n_config < 0");
+    }
+    if(m_n_config == 0) {
+      this->_invalidate();
+      return;
+    }
+
+    m_current = notstd::make_cloneable<Configuration>(_scel, this->source(0));
+    m_current->init_occupation();
+
+    reset_properties(*m_current);
+    this->_initialize(&(*m_current));
+
+    // Make initial random config
+    this->randomize();
+    _set_step(0);
+    _current().set_source(this->source(step()));
+  }
+
+  /// Set m_current to correct value at specified step and return a reference to it
+  void ConfigEnumRandomOccupations::increment() {
+
+    this->_increment_step();
+    if(step() < m_n_config) {
+      this->randomize();
+      _current().set_source(this->source(step()));
+    }
+    else {
+      this->_invalidate();
+    }
+
+  }
+
+  void ConfigEnumRandomOccupations::randomize() {
+    for(Index i = 0; i < m_current->size(); ++i) {
+      m_current->set_occ(i, m_mtrand->randInt(m_max_allowed[i]));
+    }
+  }
+
+}
+

--- a/src/casm/clex/SuperConfigEnum.cc
+++ b/src/casm/clex/SuperConfigEnum.cc
@@ -34,8 +34,8 @@ namespace CASM {
 
     "  primitive_only: bool (default=true)\n"
     "    If true, only the primitive form of a configuration is saved in the      \n"
-    "    otherwise, both primitive and non-primitive configurations are saved.    \n"
-    "\n"
+    "    otherwise, both primitive and non-primitive configurations are saved.    \n\n"
+
     "  filter: string (optional, default=None)\n"
     "    A query command to use to filter which configurations are kept.          \n"
     "\n"
@@ -193,7 +193,7 @@ namespace CASM {
       return notstd::make_unique<SuperConfigEnum>(scel, subconfig.begin(), subconfig.end());
     };
 
-    int returncode = insert_configs(
+    int returncode = insert_configs_via_lattice_enum(
                        enumerator_name,
                        primclex,
                        superlat_enum->begin(),

--- a/src/casm/clex/SuperConfigEnum.cc
+++ b/src/casm/clex/SuperConfigEnum.cc
@@ -34,7 +34,8 @@ namespace CASM {
 
     "  primitive_only: bool (default=true)\n"
     "    If true, only the primitive form of a configuration is saved in the      \n"
-    "    otherwise, both primitive and non-primitive configurations are saved.    \n\n"
+    "    configuration list. Otherwise, both primitive and non-primitive          \n"
+    "    configurations are saved.    \n\n"
 
     "  filter: string (optional, default=None)\n"
     "    A query command to use to filter which configurations are kept.          \n"

--- a/tests/unit/SConscript
+++ b/tests/unit/SConscript
@@ -51,6 +51,7 @@ unit_test = lenv.Program(os.path.join(lenv['UNIT_TEST_BINDIR'],'unit_test'),
                           lenv['boost_filesystem'],
                           lenv['boost_regex'],
                           lenv['boost_chrono'],
+                          lenv['boost_program_options'],
                           lenv['dl'],
                           'casm'])
 
@@ -102,6 +103,7 @@ for i, src_name in enumerate(test_name):
                          lenv['boost_system'], 
                          lenv['boost_filesystem'],
                          lenv['boost_regex'],
+                         lenv['boost_program_options'],
                          lenv['dl'],
                          'casm'])
   

--- a/tests/unit/clex/ConfigEnumRandomOccupations_test.cpp
+++ b/tests/unit/clex/ConfigEnumRandomOccupations_test.cpp
@@ -1,0 +1,62 @@
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+/// What is being tested:
+#include "casm/clex/ConfigEnumRandomOccupations.hh"
+
+/// What is being used to test it:
+
+#include "Common.hh"
+#include "FCCTernaryProj.hh"
+#include "casm/external/MersenneTwister/MersenneTwister.h"
+#include "casm/clex/ScelEnum.hh"
+#include "casm/completer/Handlers.hh"
+
+using namespace CASM;
+
+BOOST_AUTO_TEST_SUITE(ConfigEnumRandomOccupationsTest)
+
+BOOST_AUTO_TEST_CASE(Test1) {
+
+  test::FCCTernaryProj proj;
+  proj.check_init();
+
+  PrimClex primclex(proj.dir, null_log());
+
+  Eigen::Vector3d a, b, c;
+  std::tie(a, b, c) = primclex.get_prim().lattice().vectors();
+
+  Supercell scel = Supercell(&primclex, Lattice {2.*a, 2.*b, 2.*c}).canonical_form();
+
+  Index n_configs = 100;
+  MTRand mtrand;
+
+  {
+    ConfigEnumRandomOccupations e(scel, n_configs, mtrand);
+    BOOST_CHECK_EQUAL(n_configs, std::distance(e.begin(), e.end()));
+  }
+
+
+  {
+    jsonParser json;
+    json["existing_only"] = false;
+    json["max"] = 4;
+
+    ScelEnum e(primclex, json);
+    for(const auto &scel : e) {}
+    BOOST_CHECK_EQUAL(primclex.get_supercell_list().size(), 14);
+  }
+
+  {
+    Completer::EnumOption enum_opt;
+    jsonParser json;
+    json["n_configs"] = 200;
+    ConfigEnumRandomOccupations::run(primclex, json, enum_opt);
+    for(const auto &scel : primclex.get_supercell_list()) {
+      BOOST_CHECK_EQUAL(scel.get_config_list().size() > 0, true);
+    }
+  }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a new 'casm enum' method, "ConfigEnumRandomOccupations", to generate configurations with random occupations.  This may be useful as a starting place when the PRIM is very large, or generating Configurations in a very large Supercell. Filters may be applied as usual, and at this time no effort is made to apply constraints before filtering. The description is as follows:

```
ConfigEnumRandomOccupations: 

  supercells: ScelEnum JSON settings (default='{"existing_only"=true}')
    Indicate supercells to enumerate all occupational configurations in. May 
    be a JSON array of supercell names, or a JSON object specifying          
    supercells in terms of size and unit cell. By default, all existing      
    supercells are used. See 'ScelEnum' description for details.         

  n_config: integer (optional, default=100) 
    How many random configurations to generate. Includes duplicate and pre-
    existing configurations.                                                 

  primitive_only: bool (default=true)
    If true, only the primitive form of a configuration is saved in the      
    configuration list. Otherwise, both primitive and non-primitive          
    configurations are saved. 

  filter: string (optional, default=None)
    A query command to use to filter which Configurations are kept.          

  Examples:
    To enumerate 200 random occupations in supercells up to and including size 4:
      casm enum --method ConfigEnumRandomOccupations -i 
        '{"supercell":{"max":4}, "n_config": 200}' 

    To enumerate 200 random occupations in all existing supercells:
      casm enum --method ConfigEnumRandomOccupations -i '{"n_config": 200}' 

    To enumerate 100 random occupations in all existing supercells:
      casm enum --method ConfigEnumRandomOccupations' 

    To enumerate 200 random occupations in particular supercells:
      casm enum --method ConfigEnumRandomOccupations -i 
      '{ 
        "supercells": { 
          "name": [
            "SCEL1_1_1_1_0_0_0",
            "SCEL2_1_2_1_0_0_0",
            "SCEL4_1_4_1_0_0_0"
          ]
        }, 
        "n_config": 200
      }' 

```