### PR TITLE
bugfix for 0-magmoms getting printed

### DIFF
--- a/python/vasp/vasp/io/incar.py
+++ b/python/vasp/vasp/io/incar.py
@@ -95,7 +95,8 @@ class Incar(object):
                             if len(item)==1:
                                 temp.append(float(value))
                             else:
-                                temp.append(str(item[0])+'*'+str(float(item[1])))
+                                if item[0] != 0:
+                                    temp.append(str(item[0])+'*'+str(float(item[1])))
                         except ValueError:
                             raise IncarError("Could not convert '" + tag + "' : '" + self.tags[tag] + "' to float list")
                     self.tags[tag] = temp
@@ -180,7 +181,8 @@ class Incar(object):
                                     if site.occupant == name:
                                         count += 1
                                 if species[name].alias == alias:
-                                    self.tags[key].append( str(count) + "*" + str(species[name].tags[key]) )
+                                    if count > 0:
+                                        self.tags[key].append( str(count) + "*" + str(species[name].tags[key]) )
 
     def write(self, filename):
         try:


### PR DESCRIPTION
A bug existed where if a MAGMOM was specified for a species in the SPECIES file, but that specie was not present, then 0*[magmom] would get printed in the INCAR. E.g.:

SPECIES has A and B, with MAGMOMs of 4 and 5
some_config has 4*A and 0*B

INCAR will end up with:

MAGMOM: 4*4 0*5

VASP will proceed to fail with a MAGMOM error saying something about too many entries, as 0*5 gets interpreted as "0 0 0 0 0" I think.

This causes the job to crash repeatedly  