### PR TITLE
Tolerance Issue: Fixed missing initialization in constructor

### DIFF
--- a/include/casm/clusterography/jsonClust.hh
+++ b/include/casm/clusterography/jsonClust.hh
@@ -15,7 +15,7 @@ namespace CASM {
     double m_tol;
   public:
     ClustJsonHelper(ValueType &_value, const Structure &_struc, double _tol = TOL) :
-      m_value(_value), m_struc(_struc) {};
+      m_value(_value), m_struc(_struc), m_tol(TOL) {};
 
     ValueType &value() {
       return m_value;


### PR DESCRIPTION
This fixes a missed tolerance initialization in ClustJsonHelper, introduced by PR #76. This was causing Orbitrees to be deserialized improperly.