### PR TITLE
0.2.X compare bug

### DIFF
--- a/include/casm/clusterography/Cluster_impl.hh
+++ b/include/casm/clusterography/Cluster_impl.hh
@@ -263,7 +263,7 @@ namespace CASM {
     Index i, j;
 
     for(j = 0; j < size(); j++) {
-      if(test_elem.compare(at(j), tol))
+      if(test_elem.almost_equal(at(j), tol))
         return j;
     }
 
@@ -279,7 +279,7 @@ namespace CASM {
     index.reserve(test_cluster.size());
     for(i = 0; i < test_cluster.size(); i++) {
       for(j = 0; j < size(); j++) {
-        if(test_cluster[i].compare(at(j), tol) && !index.contains(j))
+        if(test_cluster[i].almost_equal(at(j), tol) && !index.contains(j))
           break;
       }
       if(j == size()) {
@@ -892,7 +892,7 @@ namespace CASM {
     Index i, j;
     for(i = 0; i < LHS.size(); i++) {
       for(j = 0; j < RHS.size(); j++) {
-        if((LHS[i].compare(RHS[j], tol)) && (!check_ind[j])) {
+        if((LHS[i].almost_equal(RHS[j], tol)) && (!check_ind[j])) {
           check_ind[j] = true;
           break;
         }

--- a/include/casm/crystallography/Coordinate.hh
+++ b/include/casm/crystallography/Coordinate.hh
@@ -121,6 +121,8 @@ namespace CASM {
       return !(*this == RHS);
     }
 
+    bool almost_equal(const Coordinate &RHS, double tol) const;
+
     /// Returns true if this->min_dist(RHS)<tol
     bool compare(const Coordinate &RHS, double tol = TOL) const;
 

--- a/include/casm/crystallography/Site.hh
+++ b/include/casm/crystallography/Site.hh
@@ -50,6 +50,7 @@ namespace CASM {
     bool compare(const Site &test_site, const Coordinate &shift, double compare_tol = TOL) const;
     bool compare_type(const Site &test_site) const; //Ivy
     bool operator==(const Site &test_site) const;
+    bool almost_equal(const Site &test_site, double tol) const;
 
     //checks to see if species with name 'name' is allowed at site.
     bool contains(const std::string &name) const;

--- a/src/casm/crystallography/Coordinate.cc
+++ b/src/casm/crystallography/Coordinate.cc
@@ -42,7 +42,7 @@ namespace CASM {
 
   //********************************************************************
 
-  Coordinate &Coordinate::operator -=(const Coordinate &RHS) {
+  Coordinate &Coordinate::operator-=(const Coordinate &RHS) {
     cart() -= RHS.cart();
     return *this;
 
@@ -57,7 +57,14 @@ namespace CASM {
   //********************************************************************
 
   bool Coordinate::operator==(const Coordinate &RHS) const {
-    return almost_equal(m_cart_coord, RHS.m_cart_coord);
+    return CASM::almost_equal(m_cart_coord, RHS.m_cart_coord);
+  }
+
+
+  //********************************************************************
+
+  bool Coordinate::almost_equal(const Coordinate &RHS, double tol) const {
+    return dist(RHS) < tol;
   }
 
 

--- a/src/casm/crystallography/Site.cc
+++ b/src/casm/crystallography/Site.cc
@@ -170,6 +170,12 @@ namespace CASM {
     return (compare_type(test_site) && Coordinate::operator==(test_site));
   }
 
+  //*******************************************************************************************
+
+  bool Site::almost_equal(const Site &test_site, double tol) const {
+    return (compare_type(test_site) && dist(test_site) < tol);
+  }
+
   //****************************************************
 
   bool Site::contains(const std::string &name) const {

--- a/tests/unit/FCCTernaryProj.hh
+++ b/tests/unit/FCCTernaryProj.hh
@@ -184,7 +184,7 @@ namespace test {
         auto end = boost::sregex_iterator();
         auto count = std::distance(begin, end);
 
-        BOOST_CHECK_EQUAL(count, 5);
+        BOOST_CHECK_MESSAGE(count == 5, m_p.gets());
       }
 
       // check that you can't overwrite without using -f

--- a/tests/unit/ZrOProj.hh
+++ b/tests/unit/ZrOProj.hh
@@ -124,7 +124,7 @@ namespace test {
         auto end = boost::sregex_iterator();
         auto count = std::distance(begin, end);
 
-        BOOST_CHECK_EQUAL(count, 5);
+        BOOST_CHECK_MESSAGE(count == 5, m_p.gets());
       }
 
       // check that you can't overwrite without using -f

--- a/tests/unit/clex/NeighborList_test.cpp
+++ b/tests/unit/clex/NeighborList_test.cpp
@@ -129,6 +129,8 @@ BOOST_AUTO_TEST_CASE(Proj) {
   proj.check_init();
 
   PrimClex primclex(proj.dir, null_log());
+  primclex.settings().set_crystallography_tol(TOL);
+  double tol = primclex.crystallography_tol();
   Structure prim = primclex.get_prim();
   const DirectoryStructure &dir = primclex.dir();
   const ProjectSettings &set = primclex.settings();
@@ -141,9 +143,9 @@ BOOST_AUTO_TEST_CASE(Proj) {
   );
 
   // generate orbitree
-  SiteOrbitree tree(prim.lattice());
+  SiteOrbitree tree(prim.lattice(), tol);
   jsonParser bspecs_json(proj.bspecs());
-  tree = make_orbitree(prim, bspecs_json);
+  tree = make_orbitree(prim, bspecs_json, tol);
 
   // expand the nlist to contain 'tree'
   std::set<UnitCellCoord> nbors;

--- a/tests/unit/clusterography/Clusterography_test.cpp
+++ b/tests/unit/clusterography/Clusterography_test.cpp
@@ -5,6 +5,7 @@
 #include "casm/clusterography/Orbitree.hh"
 
 /// What is being used to test it:
+#include "casm/crystallography/Molecule.hh"
 #include "casm/crystallography/Structure.hh"
 #include "casm/clex/PrimClex.hh"
 #include "casm/app/AppIO.hh"
@@ -33,6 +34,7 @@ BOOST_AUTO_TEST_CASE(ClusterographyTest) {
   // read test file
   fs::path test_cases_path("tests/unit/clusterography/test_cases.json");
   jsonParser tests(test_cases_path);
+  double tol = TOL;
 
   for(auto test_it = tests.begin(); test_it != tests.end(); ++test_it) {
 
@@ -51,8 +53,8 @@ BOOST_AUTO_TEST_CASE(ClusterographyTest) {
     Structure prim(read_prim(j["prim"]));
 
     // generate cluster orbits
-    SiteOrbitree tree(prim.lattice());
-    tree = make_orbitree(prim, j["bspecs"]);
+    SiteOrbitree tree(prim.lattice(), tol);
+    tree = make_orbitree(prim, j["bspecs"], tol);
 
     jsonParser clust_json;
     to_json(jsonHelper(tree, prim), clust_json);


### PR DESCRIPTION
This fixes a misused comparison function introduced in #76 that was causing test failures because of contextually wrong comparisons of Sites in a cluster.