### PR TITLE
0.2.X travisci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,3 @@ libtool
 stamp-h1
 
 #Other stuff
-*.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,80 @@
+sudo: false
+
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - gcc-4.8
+          - g++-4.8
+          - libboost-all-dev
+      env:
+        - CC=gcc-4.8
+        - CXX=g++-4.8
+        
+        # set environment variables for boost
+        - CASM_BOOST_INCLUDEDIR="/usr/include/"
+        - CASM_BOOST_LIBDIR="/usr/lib/x86_64-linux-gnu/"
+        - CASM_BOOST_NO_CXX11_SCOPED_ENUMS=1
+
+    - os: osx
+      compiler: clang
+      env:
+        - CASM_BOOST_NO_CXX11_SCOPED_ENUMS=1
+        
+
+before_install:
+
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then 
+        CASM_NCPU=2;
+    fi
+  
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
+        brew install boost@1.55 scons;
+        CASM_NCPU=2;
+    fi
+  
+  # check g++ version
+  - g++ --version
+  
+  # check scons
+  - scons --version
+  
+  # check python
+  - python --version
+  - python -c "import sys; print sys.path"
+  
+  
+  # install other python dependencies
+  - pip install --upgrade pip
+  - pip install --user -r python/casm/requirements.txt
+  
+  # install pbs
+  - git clone https://github.com/prisms-center/pbs.git
+  - export PYINSTALL=/home/travis/.local
+  - export BIN=/home/travis/.local/bin
+  - echo $PYINSTALL
+  - echo $BIN
+  - cd pbs && git checkout v2.0.0 && make install && cd ..  
+  - unset BIN
+  - unset PYINSTALL
+  - export PATH=$PATH:$BIN
+  - export PYTHONPATH=/home/travis/.local/lib/python2.7/site-packages:$PYTHONPATH
+  
+  # check env
+  - printenv
+  
+
+script: 
+  - set -e
+  - 'echo "CASM_NCPU: $CASM_NCPU"'
+  - scons configure
+  - scons -j $CASM_NCPU
+  - scons unit -j $CASM_NCPU

--- a/SConstruct
+++ b/SConstruct
@@ -386,9 +386,7 @@ candidates = [
 cpppath = [x for x in candidates if x is not None]
 
 # link paths
-build_lib_paths = [env['LIBDIR']]
-if 'BOOST_PREFIX' in env and env['BOOST_PREFIX'] is not None:
-  build_lib_paths.append(join(env['BOOST_PREFIX'], 'lib'))
+build_lib_paths = [env['LIBDIR'], env['BOOST_LIBDIR']]
 Export('build_lib_paths')
 
 # link flags

--- a/SConstruct
+++ b/SConstruct
@@ -658,7 +658,7 @@ if 'configure' in COMMAND_LINE_TARGETS:
   def if_failed(msg):
     print "\nConfiguration checks failed."
     print msg
-    exit()
+    exit(1)
   
   # Note: CheckLib with autoadd=1 (default), because some libraries depend on each other
   
@@ -693,5 +693,5 @@ if 'configure' in COMMAND_LINE_TARGETS:
   
   
   print "Configuration checks passed."
-  exit()
+  exit(0)
   

--- a/python/casm/requirements.txt
+++ b/python/casm/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pandas
+scikit-learn
+scoop
+deap
+bokeh


### PR DESCRIPTION
This PR implements TravisCI testing.  Currently tests built via scons and are performed for:
- Ubuntu 14 (trusty), gcc-4.8, libboost-all-dev (1.54.0.1ubuntu1)
- MacOS, clang, boost@1.55

It installs the latest versions via pip of:
- numpy
- pandas
- scikit-learn
- scoop
- deap
- bokeh
- And 'prisms-center/pbs' v2.0.0 from source. We'll soon release v3 via PyPI too.

The CASM Python components are still not getting tested though.

