### PR TITLE
removed extraneous mag argument to poscar.Site

### DIFF
--- a/python/vasp/vasp/io/poscar.py
+++ b/python/vasp/vasp/io/poscar.py
@@ -20,9 +20,8 @@ class Site:
             self.occupant = CASM specie name, empty string by default
             self.occ_alias = alias (POTCAR) name, empty string by default
             self.position = np.array coordinate
-            self.mag = MAGMOM value, None by default
     """
-    def __init__(self, cart, position, mag = None, SD_FLAG = "", occupant = "", occ_alias = ""):
+    def __init__(self, cart, position, SD_FLAG = "", occupant = "", occ_alias = ""):
         """ Site constructor """
         self.cart = cart
         self.SD_FLAG = SD_FLAG


### PR DESCRIPTION
This PR is a quick bug fix in the vasp wrapper POSCAR reading file. 

There was an extraneous argument that was shifting the input arguments in a later call to cause occupant names to be printed as Selective Dynamics Flags. This showed up as a double occupant name in the first copy of POS to POSCAR in the run.0 directory or upon casm-calc --setup. This bug would have prevented proper use of Selective Dynamics. 