### PR TITLE
Doubleprintfix

### DIFF
--- a/python/vasp/vasp/io/poscar.py
+++ b/python/vasp/vasp/io/poscar.py
@@ -20,9 +20,8 @@ class Site:
             self.occupant = CASM specie name, empty string by default
             self.occ_alias = alias (POTCAR) name, empty string by default
             self.position = np.array coordinate
-            self.mag = MAGMOM value, None by default
     """
-    def __init__(self, cart, position, mag = None, SD_FLAG = "", occupant = "", occ_alias = ""):
+    def __init__(self, cart, position, SD_FLAG = "", occupant = "", occ_alias = ""):
         """ Site constructor """
         self.cart = cart
         self.SD_FLAG = SD_FLAG

--- a/src/casm/app/status.cc
+++ b/src/casm/app/status.cc
@@ -97,10 +97,10 @@ namespace CASM {
 
     args.log <<
              "Enumerate supercells\n\
-- Execute: 'casm enum --supercells --max V' to enumerate supercells up to \n\
+- Execute: 'casm enum --method ScelEnum --max V' to enumerate supercells up to \n\
   volume V (units: number of primitive cells).                            \n\
 - Supercells are listed in the SCEL file.\n\
-- See 'casm enum --desc' for extended help documentation on how to use the\n\
+- See 'casm enum --desc ScelEnum' for extended help documentation on how to use the\n\
   '--matrix' and '--lattice-directions' options to perform restricted     \n\
   supercell enumeration (i.e. 2d, 1d, multiples of other supercells).     \n\
 - See 'casm format' for a description and location of the  \n\
@@ -115,12 +115,12 @@ namespace CASM {
     args.log <<
              "Enumerate configurations\n\
 - Several options are possible:                                        \n\
-- Execute: 'casm enum --configs --all' to enumerate configurations for \n\
+- Execute: 'casm enum --method ConfigEnumAllOccupations --all' to enumerate configurations for \n\
   for all supercells.                                                  \n\
-- Execute: 'casm enum --configs --min MINV --max MAXV' to enumerate    \n\
+- Execute: 'casm enum --method ConfigEnumAllOccupations --min MINV --max MAXV' to enumerate    \n\
   configurations for supercells ranging in volume from MINV to MAXV    \n\
   (units: number of primitive cells).                                  \n\
-- Execute: 'casm enum --configs --scellname NAME' to enumerate         \n\
+- Execute: 'casm enum --method ConfigEnumAllOccupations --scelnames NAME' to enumerate         \n\
   configurations for a particular supercell.                           \n\
 - Generated configurations are listed in the 'config_list.json' file.  \n\
   This file should not usually be edited manually.                     \n\
@@ -148,7 +148,7 @@ Instructions for volume relaxed VASP energies:                         \n\n\
   'casm format --vasp' for a description and location of the VASP      \n\
   settings files.                                                      \n\
 - Select which configurations to calculate properties for using the    \n\
-  'casm select' command. Use 'casm select --set on' to select all      \n\
+  'casm select' command. Use 'casm select --set-on' to select all      \n\
   configurations. By default, the 'selected' state of each             \n\
   configuration is stored by CASM in the master config_list.json file, \n\
   located in the hidden '.casm' directory. The standard selections     \n\


### PR DESCRIPTION
This PR fixes an error to the vasp.io.poscar.Site constructor that had an extraneous argument that caused printing of site occupant and site occupant alias instead of SD_FLAG and site occupant