### PR TITLE
map doesn't autoconvert to list in python3

### DIFF
--- a/python/casm/casm/qewrapper/relax.py
+++ b/python/casm/casm/qewrapper/relax.py
@@ -500,9 +500,9 @@ class Relax(object):
         else:
             output["coord_mode"] = "cartesian" + qrun.coord_mode
 
-        output["relaxed_forces"] = [noindent.NoIndent(v) for v in (map(lambda y: map(lambda x: x*13.605698066/0.52918,y), qrun.forces ))] #convert Ry/bohr to eV/angst
+        output["relaxed_forces"] = [noindent.NoIndent(v) for v in list(map(lambda y: list(map(lambda x: x*13.605698066/0.52918,y)), qrun.forces ))] #convert Ry/bohr to eV/angst
 
-        output["relaxed_lattice"] = [noindent.NoIndent(v) for v in (map(lambda y: map(lambda x: x* 0.52918,y),qrun.lattice) )] #convert bohr to angst
+        output["relaxed_lattice"] = [noindent.NoIndent(v) for v in list(map(lambda y: list(map(lambda x: x* 0.52918,y)),qrun.lattice) )] #convert bohr to angst
 
         output["relaxed_basis"] = [noindent.NoIndent(v) for v in qrun.basis]
 

--- a/python/casm/casm/scripts/casm_calc.py
+++ b/python/casm/casm/scripts/casm_calc.py
@@ -6,6 +6,7 @@ import json
 from os import getcwd
 from os.path import join, abspath
 import sys
+import six
 
 from casm.misc import compat, noindent
 from casm.project import Project, Selection
@@ -128,7 +129,9 @@ def main(argv = None):
             output = Relax.properties(finaldir)
           calc_props = proj.dir.calculated_properties(configname, clex)
           print("writing:", calc_props)
-          compat.dump(json, output, calc_props, 'w', cls=noindent.NoIndentEncoder, indent=4, sort_keys=True)
+          with open(calc_props, 'wb') as f:
+              f.write(six.u(json.dumps(output, cls=noindent.NoIndentEncoder, indent=2)).encode('utf-8'))
+        #compat.dump(json, output, calc_props, 'w', cls=noindent.NoIndentEncoder, indent=4, sort_keys=True)
         except:
           print(("Unable to report properties for directory {}.\n" 
                 "Please verify that it contains a completed calculation.".format(configdir)))


### PR DESCRIPTION
converts map required to convert QE units to casm units to a list so it can be JSON serialized into properties.calc.json