### PR TITLE
also search for fermi energy

### DIFF
--- a/python/casm/casm/quantumespresso/qeio/qerun.py
+++ b/python/casm/casm/quantumespresso/qeio/qerun.py
@@ -139,7 +139,10 @@ class QErun:
                line = line.strip()
                m = re.search("highest occupied level.*|.*Fermi energy is.*",line)
         try:
-            self.efermi = float(line.split()[-1])
+            if line.split()[-1]=="ev":
+                self.efermi = float(line.split()[-2])
+            else:
+                self.efermi = float(line.split()[-1])
         except ValueError:
             raise QErunError("could not convert efermi to float")
 

--- a/python/casm/casm/quantumespresso/qeio/qerun.py
+++ b/python/casm/casm/quantumespresso/qeio/qerun.py
@@ -130,14 +130,14 @@ class QErun:
         f.seek(0)
         
         line=f.readline()
-        m = re.search("highest occupied level.*",line)
+        m = re.search("highest occupied level.*|.*Fermi energy is.*",line)
         if not m:
             while not m:
                line = f.readline()
                if line=='':
-                    raise QErunError("EOF reach without finding highest occupied level")
+                    raise QErunError("EOF reach without finding highest occupied level or Fermi energy")
                line = line.strip()
-               m = re.search("highest occupied level.*",line)
+               m = re.search("highest occupied level.*|.*Fermi energy is.*",line)
         try:
             self.efermi = float(line.split()[-1])
         except ValueError:


### PR DESCRIPTION
This corrects the qerun search for the Fermi level to also search for "Fermi energy is" along with "highest occupied level" so that the parsing works for insulating and metallic systems equally. 