### PR TITLE
Fixed regex for removing brackets and quotes in VASP io routines

### DIFF
--- a/python/casm/casm/vasp/io/incar.py
+++ b/python/casm/casm/vasp/io/incar.py
@@ -197,9 +197,9 @@ class Incar(object):
                 pass
             else:
                 if tag.lower() in VASP_TAG_SITEF_LIST + VASP_TAG_SPECF_LIST:
-                    incar_write.write('{} = {}\n'.format(tag.upper(),remove_chars(self.tags[tag], "[\[\],]'")))
+                    incar_write.write('{} = {}\n'.format(tag.upper(),remove_chars(self.tags[tag], "[\[\],']")))
                 elif tag.lower() in VASP_TAG_SPECI_LIST:
-                    incar_write.write('{} = {}\n'.format(tag.upper(),remove_chars(self.tags[tag], "[\[\],]'")))
+                    incar_write.write('{} = {}\n'.format(tag.upper(),remove_chars(self.tags[tag], "[\[\],']")))
                 elif tag.lower() in VASP_TAG_BOOL_LIST:
                     if self.tags[tag] == True:
                         incar_write.write('{} = .TRUE.\n'.format(tag.upper()))


### PR DESCRIPTION
The regex pattern for removing quotes and brackets from string representations of lists had a typo.

The single quote was outside of the regex brackets. That led to partial substitution and corrupted INCAR entries for list type entries. For instance, when using LDA+U the following is written to INCAR files:

```
LDAUJ = [0.0, 0.0, 0.0]
LDAUL = [0, 2, 0]
LDAUU = [0.0, 3.9, 0.0]
MAGMOM = 4*0', '4*4', '12*0']
```

This is not correct and VASP will bail. This patch corrects the replacement pattern by moving the single quote. INCAR entries after patching look like:

```
LDAUL = 0 2 0
LDAUU = 0.0 3.9 0.0
LDAUJ = 0.0 0.0 0.0
MAGMOM = 4*0 4*4 12*0
```
