### PR TITLE
added import statement for proper warning usage

### DIFF
--- a/python/casm/casm/vaspwrapper/vaspwrapper.py
+++ b/python/casm/casm/vaspwrapper/vaspwrapper.py
@@ -4,7 +4,7 @@ from builtins import *
 import os, shutil, six, re, subprocess, json
 import warnings
 import casm.vasp.io
-
+from casm import vasp
 class VaspWrapperError(Exception):
     def __init__(self,msg):
         self.msg = msg


### PR DESCRIPTION
the warnings in vasp_input_file_names cannot recognize the vasp module as it was not imported properly in this file. 