### PR TITLE
1.0.X query equivalents

### DIFF
--- a/include/casm/app/DBInterface_impl.hh
+++ b/include/casm/app/DBInterface_impl.hh
@@ -70,4 +70,3 @@ namespace CASM {
 }
 
 #endif
-

--- a/include/casm/app/query/QueryIO.hh
+++ b/include/casm/app/query/QueryIO.hh
@@ -1,0 +1,59 @@
+#ifndef CASM_app_query_QueryIO
+#define CASM_app_query_QueryIO
+
+namespace CASM {
+
+  class PermuteIterator;
+  template<typename ValueType>
+  struct QueryData;
+
+  namespace adapter {
+
+    template <typename ToType, typename FromType> struct Adapter;
+
+    template<typename DataObject>
+    struct Adapter<DataObject, QueryData<DataObject>> {
+      DataObject const &operator()(QueryData<DataObject> const &adaptable) const;
+    };
+
+  }
+
+  /// Collect information during `enumerate_configurations` function for optional output
+  template<typename ValueType>
+  struct QueryData {
+
+    QueryData(PrimClex const &_primclex,
+              ValueType const &_value,
+              bool _include_equivalents = false,
+              Index _equivalent_index = 0,
+              PermuteIterator const *_permute_it = nullptr);
+
+    PrimClex const &primclex;
+    ValueType const &value;
+    bool include_equivalents;
+    Index equivalent_index;
+    PermuteIterator const *permute_it;
+  };
+
+  namespace QueryIO {
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> equivalent_index();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc();
+
+    template <typename QueryDataType>
+    Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation();
+
+  }
+
+}
+
+#endif

--- a/include/casm/app/query/QueryIO.hh
+++ b/include/casm/app/query/QueryIO.hh
@@ -18,7 +18,7 @@ namespace CASM {
 
   }
 
-  /// Collect information during `enumerate_configurations` function for optional output
+  /// Data structure to collect value (Supercell, Configuration, etc.) and data for query formatting
   template<typename ValueType>
   struct QueryData {
 
@@ -28,27 +28,41 @@ namespace CASM {
               Index _equivalent_index = 0,
               PermuteIterator const *_permute_it = nullptr);
 
+    /// Provides access to project data
     PrimClex const &primclex;
+
+    /// The object under consideration (Supercell, Configuration, etc.)
     ValueType const &value;
+
+    /// True if non-canonical equivalents are also being queried
     bool include_equivalents;
+
+    /// Index incremented for each non-canonical equivalent
     Index equivalent_index;
+
+    /// Permutation that transforms the canonical form to the current non-canonical equivalent value
     PermuteIterator const *permute_it;
   };
 
   namespace QueryIO {
 
+    /// Index incremented for each non-canonical equivalent (QueryDataType::equivalent_index)
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> equivalent_index();
 
+    /// Index of permute factor group operation in the supercell factor group (QueryDataType::permute_it->factor_group_index())
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op();
 
+    /// Index of permute factor group operation in the prim factor group (QueryDataType::permute_it->prim_factor_group_index())
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op();
 
+    /// Description of permute factor group operation in the prim factor group
     template <typename QueryDataType>
     GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc();
 
+    /// Permute translation operation as (i, j, k) multiples of the prim lattice vectors
     template <typename QueryDataType>
     Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation();
 

--- a/include/casm/app/query/QueryIO_impl.hh
+++ b/include/casm/app/query/QueryIO_impl.hh
@@ -1,0 +1,98 @@
+#ifndef CASM_app_query_QueryIO_impl
+#define CASM_app_query_QueryIO_impl
+
+#include "casm/app/query/QueryIO.hh"
+#include "casm/casm_io/dataformatter/DatumFormatterAdapter.hh"
+#include "casm/crystallography/Structure.hh"
+#include "casm/symmetry/PermuteIterator.hh"
+#include "casm/symmetry/SupercellSymInfo_impl.hh"
+
+namespace CASM {
+
+  namespace adapter {
+
+    template<typename DataObject>
+    DataObject const &Adapter<DataObject, QueryData<DataObject>>::operator()(
+    QueryData<DataObject> const &adaptable) const {
+      return adaptable.value;
+    }
+
+  }
+
+  template<typename ValueType>
+  QueryData<ValueType>::QueryData(PrimClex const &_primclex,
+                                  ValueType const &_value,
+                                  bool _include_equivalents,
+                                  Index _equivalent_index,
+                                  PermuteIterator const *_permute_it):
+    primclex(_primclex),
+    value(_value),
+    include_equivalents(_include_equivalents),
+    equivalent_index(_equivalent_index),
+    permute_it(_permute_it) {}
+
+  namespace QueryIO {
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> equivalent_index() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "equivalent_index",
+               "Index that counts over distinct symmetrically equivalent objects",
+      [](QueryDataType const & data) -> Index {
+        return data.equivalent_index;
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "permute_scel_factor_group_op",
+               "Factor group operation (applied before translation operation) of the permutation "
+               "that generated the equivalent object, as its index into the prim factor group",
+      [](QueryDataType const & data) -> Index {
+        return data.permute_it->factor_group_index();
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "permute_factor_group_op",
+               "Factor group operation (applied before translation operation) of the permutation "
+               "that generated the equivalent object, as its index into the prim factor group",
+      [](QueryDataType const & data) -> Index {
+        return data.permute_it->prim_factor_group_index();
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc() {
+      return GenericDatumFormatter<std::string, QueryDataType>(
+               "permute_factor_group_op_desc",
+               "Description of prim factor group operation that generated equivalent object",
+      [](QueryDataType const & data) -> std::string {
+
+        auto const &factor_group_op = data.permute_it->factor_group()[data.permute_it->factor_group_index()];
+        auto const &lattice = data.primclex.prim().lattice();
+        std::stringstream ss;
+        ss << "'" << brief_description(factor_group_op, lattice) << "'";
+        return ss.str();
+      });
+    }
+
+    template <typename QueryDataType>
+    Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation() {
+      return Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType>(
+               "permute_translation",
+               "Translation (applied after factor group operation) of the permutation that generated "
+               "the equivalent object, as a linear combination of the lattice vectors",
+      [](QueryDataType const & data) -> Eigen::Vector3l {
+        return data.permute_it->sym_info().unitcell_index_converter()(data.permute_it->translation_index());
+      });
+    }
+
+  }
+
+}
+
+#endif

--- a/include/casm/app/query/QueryIO_impl.hh
+++ b/include/casm/app/query/QueryIO_impl.hh
@@ -37,7 +37,8 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> equivalent_index() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "equivalent_index",
-               "Index that counts over distinct symmetrically equivalent objects",
+               "[--include-equivalents query only] Index that counts over distinct symmetrically "
+               "equivalent objects",
       [](QueryDataType const & data) -> Index {
         return data.equivalent_index;
       });
@@ -47,8 +48,9 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "permute_scel_factor_group_op",
-               "Factor group operation (applied before translation operation) of the permutation "
-               "that generated the equivalent object, as its index into the prim factor group",
+               "[--include-equivalents query only] Factor group operation (applied before "
+               "translation operation) of the permutation that generated the equivalent object, as "
+               "its index into the supercell factor group",
       [](QueryDataType const & data) -> Index {
         return data.permute_it->factor_group_index();
       });
@@ -58,8 +60,9 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "permute_factor_group_op",
-               "Factor group operation (applied before translation operation) of the permutation "
-               "that generated the equivalent object, as its index into the prim factor group",
+               "[--include-equivalents query only] Factor group operation (applied before "
+               "translation operation) of the permutation that generated the equivalent object, as "
+               "its index into the prim factor group",
       [](QueryDataType const & data) -> Index {
         return data.permute_it->prim_factor_group_index();
       });
@@ -69,7 +72,8 @@ namespace CASM {
     GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc() {
       return GenericDatumFormatter<std::string, QueryDataType>(
                "permute_factor_group_op_desc",
-               "Description of prim factor group operation that generated equivalent object",
+               "[--include-equivalents query only] Description of prim factor group operation that "
+               "generated the equivalent object.",
       [](QueryDataType const & data) -> std::string {
 
         auto const &factor_group_op = data.permute_it->factor_group()[data.permute_it->factor_group_index()];
@@ -84,8 +88,9 @@ namespace CASM {
     Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation() {
       return Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType>(
                "permute_translation",
-               "Translation (applied after factor group operation) of the permutation that generated "
-               "the equivalent object, as a linear combination of the lattice vectors",
+               "[--include-equivalents query only] Translation (applied after factor "
+               "group operation) of the permutation that generated the equivalent object, as "
+               "(i, j, k) multiples of the prim lattice vectors.",
       [](QueryDataType const & data) -> Eigen::Vector3l {
         return data.permute_it->sym_info().unitcell_index_converter()(data.permute_it->translation_index());
       });

--- a/include/casm/casm_io/dataformatter/DataFormatterDecl.hh
+++ b/include/casm/casm_io/dataformatter/DataFormatterDecl.hh
@@ -212,6 +212,15 @@ namespace CASM {
   template<typename DataObject>
   MatrixXdAttributeDictionary<DataObject> make_matrixxd_dictionary();
 
+
+  class jsonParser;
+  /// \brief Template to be specialized for constructing dictionaries for particular DataObject
+  ///
+  /// \ingroup DataFormatter
+  ///
+  template<typename DataObject>
+  DataFormatterDictionary<DataObject, BaseValueFormatter<jsonParser, DataObject>> make_json_dictionary();
+
 }
 
 #endif

--- a/include/casm/casm_io/dataformatter/DataFormatterTools.hh
+++ b/include/casm/casm_io/dataformatter/DataFormatterTools.hh
@@ -1169,7 +1169,8 @@ namespace CASM {
       make_scalar_dictionary<DataObject>(),
       make_vectorxi_dictionary<DataObject>(),
       make_vectorxd_dictionary<DataObject>(),
-      make_matrixxd_dictionary<DataObject>()
+      make_matrixxd_dictionary<DataObject>(),
+      make_json_dictionary<DataObject>()
     );
 
     return dict;

--- a/include/casm/casm_io/dataformatter/DataStream.hh
+++ b/include/casm/casm_io/dataformatter/DataStream.hh
@@ -6,6 +6,8 @@
 #include <functional>
 namespace CASM {
 
+  class jsonParser;
+
   /// \ingroup DataFormatter
   ///
   class DataStream {
@@ -52,6 +54,10 @@ namespace CASM {
       return *this;
     }
     */
+
+    virtual DataStream &operator<<(jsonParser const &) {
+      throw std::runtime_error("Error in DataStream input: JSON may not be input to DataStream");
+    }
 
     DataStream &operator<<(DataStream & (*F)(DataStream &)) {
       return F(*this);

--- a/include/casm/clex/ConfigIO.hh
+++ b/include/casm/clex/ConfigIO.hh
@@ -20,6 +20,7 @@ namespace CASM {
   class Configuration;
   template<typename DataObject>
   class Norm;
+  class jsonParser;
 
   /**  \addtogroup ConfigIO
        @{
@@ -447,6 +448,13 @@ namespace CASM {
 
     ConfigIO::GenericConfigFormatter<double> relaxed_magmom_per_species();
 
+    ConfigIO::GenericConfigFormatter<jsonParser> config();
+
+    ConfigIO::GenericConfigFormatter<jsonParser> configdof();
+
+    ConfigIO::GenericConfigFormatter<jsonParser> properties();
+
+    ConfigIO::GenericConfigFormatter<std::string> poscar();
   }
 
   template<>

--- a/include/casm/clex/HasCanonicalForm_impl.hh
+++ b/include/casm/clex/HasCanonicalForm_impl.hh
@@ -314,7 +314,29 @@ namespace CASM {
   template<typename Base>
   template<typename PermuteIteratorIt>
   PermuteIterator ConfigCanonicalForm<Base>::from_canonical(PermuteIteratorIt begin, PermuteIteratorIt end) const {
-    return to_canonical(begin, end).inverse();
+
+    // simplest version: use the inverse of the first element that results in the canonical form
+    // return to_canonical(begin, end).inverse();
+
+    // alternate version: the lowest index element that transforms canonical form to this
+    auto less = derived().less();
+    auto _to_canonical = begin;
+    auto _from_canonical = _to_canonical.inverse();
+    for(auto it = begin; it < end; ++it) {
+      if(less(_to_canonical, it)) {
+        _to_canonical = it;
+        _from_canonical = _to_canonical.inverse();
+      }
+      // other permutations that result in canonical config may have a lower index inverse
+      else if(!less(it, _to_canonical)) {
+        auto it_inv = it.inverse();
+        if(it_inv < _from_canonical) {
+          _from_canonical = it_inv;
+        }
+      }
+    }
+    return _from_canonical;
+
   }
 
   template<typename Base>

--- a/src/casm/clex/ConfigIO.cc
+++ b/src/casm/clex/ConfigIO.cc
@@ -1,7 +1,9 @@
 #include "casm/clex/ConfigIO.hh"
 
 #include <functional>
+#include "casm/crystallography/SimpleStructure.hh"
 #include "casm/crystallography/Structure.hh"
+#include "casm/crystallography/io/SimpleStructureIO.hh"
 #include "casm/clex/PrimClex.hh"
 #include "casm/clex/Norm.hh"
 #include "casm/clex/Calculable.hh"
@@ -10,6 +12,11 @@
 #include "casm/clex/ConfigIOStrucScore.hh"
 #include "casm/clex/ConfigIOStrain.hh"
 #include "casm/clex/ConfigMapping.hh"
+#include "casm/clex/MappedProperties.hh"
+#include "casm/clex/SimpleStructureTools.hh"
+#include "casm/clex/io/json/ConfigDoF_json_io.hh"
+#include "casm/casm_io/container/json_io.hh"
+#include "casm/casm_io/json/jsonParser.hh"
 #include "casm/casm_io/Log.hh"
 #include "casm/casm_io/dataformatter/DataFormatter_impl.hh"
 #include "casm/casm_io/dataformatter/DataFormatterTools_impl.hh"
@@ -570,7 +577,44 @@ namespace CASM {
                                             has_relaxed_magmom);
     }
 
+    ConfigIO::GenericConfigFormatter<jsonParser> config() {
+      return GenericConfigFormatter<jsonParser>(
+               "config",
+               "Structure resulting from application of DoF, formatted as JSON",
+      [](Configuration const & configuration) {
+        jsonParser json = jsonParser::object();
+        to_json(make_simple_structure(configuration), json);
+        return json;
+      });
+    }
 
+    ConfigIO::GenericConfigFormatter<jsonParser> dof() {
+      return GenericConfigFormatter<jsonParser>(
+               "dof",
+               "All degrees of freedom (DoF), formatted as JSON",
+      [](Configuration const & configuration) {
+        return jsonParser {configuration.configdof()};
+      });
+    }
+
+    ConfigIO::GenericConfigFormatter<jsonParser> properties() {
+      return GenericConfigFormatter<jsonParser>(
+               "properties",
+               "All mapped properties, by calctype, formatted as JSON",
+      [](Configuration const & configuration) {
+        return jsonParser {configuration.calc_properties_map()};
+      });
+    }
+
+    ConfigIO::GenericConfigFormatter<std::string> poscar() {
+      return GenericConfigFormatter<std::string>(
+               "poscar",
+               "Structure resulting from application of DoF, formatted as VASP POSCAR",
+      [](Configuration const & configuration) {
+        return pos_string(configuration);
+      });
+
+    }
 
     /*End ConfigIO*/
   }
@@ -589,7 +633,8 @@ namespace CASM {
       scelname(),
       calc_status(),
       failure_type(),
-      point_group_name()
+      point_group_name(),
+      poscar()
     );
 
     return dict;
@@ -690,6 +735,21 @@ namespace CASM {
 
     dict.insert(
       GradCorr()
+    );
+
+    return dict;
+  }
+
+  template<>
+  DataFormatterDictionary<Configuration, BaseValueFormatter<jsonParser, Configuration>> make_json_dictionary<Configuration>() {
+
+    using namespace ConfigIO;
+    DataFormatterDictionary<Configuration, BaseValueFormatter<jsonParser, Configuration>> dict;
+
+    dict.insert(
+      config(),
+      dof(),
+      properties()
     );
 
     return dict;

--- a/src/casm/clex/SupercellIO.cc
+++ b/src/casm/clex/SupercellIO.cc
@@ -473,4 +473,10 @@ namespace CASM {
     return dict;
   }
 
+  template<>
+  DataFormatterDictionary<Supercell, BaseValueFormatter<jsonParser, Supercell>> make_json_dictionary<Supercell>() {
+    return DataFormatterDictionary<Supercell, BaseValueFormatter<jsonParser, Supercell>>();
+  }
+
+
 }

--- a/src/casm/database/Selected.cc
+++ b/src/casm/database/Selected.cc
@@ -48,6 +48,9 @@ namespace CASM {
 
     template<typename ObjType>
     bool Selected<ObjType>::evaluate(const ObjType &_obj) const {
+      if(_obj.name().find("equiv") != std::string::npos) {
+        return false;
+      }
       return m_selection->is_selected(_obj.name());
     }
 


### PR DESCRIPTION
This PR adds an option `--include-equivalents` to `casm query` to include output for all distinct configurations that are equivalent by supercell factor group symmetry to configurations in the input selection. This could be used, for example, as to plot properties of configurations and include points for symmetrically equivalent configurations.