### PR TITLE
1.0.X dof space analysis

### DIFF
--- a/include/casm/app/DBInterface_impl.hh
+++ b/include/casm/app/DBInterface_impl.hh
@@ -70,4 +70,3 @@ namespace CASM {
 }
 
 #endif
-

--- a/include/casm/app/DirectoryStructure.hh
+++ b/include/casm/app/DirectoryStructure.hh
@@ -178,11 +178,14 @@ namespace CASM {
     /// \brief Return configuration directory path
     fs::path configuration_dir(std::string configname) const;
 
-    /// \brief Return path to POS file
+    /// \brief Return path to standard POS file location
     fs::path POS(std::string configname) const;
 
-    /// \brief Return path to config.json file
+    /// \brief Return path to standard config.json file location
     fs::path config_json(std::string configname) const;
+
+    /// \brief Return path to standard structure.json file location
+    fs::path structure_json(std::string configname) const;
 
     /// \brief Return calculation settings directory path, for global settings
     fs::path calc_settings_dir(std::string calctype) const;

--- a/include/casm/app/enum/enumerate_configurations_impl.hh
+++ b/include/casm/app/enum/enumerate_configurations_impl.hh
@@ -105,6 +105,7 @@ namespace CASM {
       Index count_filtered = 0;
       Index num_before = configuration_db.size();
       log << dry_run_msg << "Enumerate configurations for: " << input_name_value_pair.first << std::endl;
+
       auto enumerator = make_enumerator_f(initial_state_index, input_name_value_pair.first, input_name_value_pair.second);
 
       for(Configuration const &configuration : enumerator) {
@@ -123,9 +124,6 @@ namespace CASM {
         }
 
         ++count;
-        if(options.filter) {
-          std::cout << "filter value: " << options.filter(configuration) << std::endl;
-        }
         if(options.filter && !options.filter(configuration)) {
           data.is_excluded_by_filter = true;
           ++count_filtered;

--- a/include/casm/app/enum/io/stream_io.hh
+++ b/include/casm/app/enum/io/stream_io.hh
@@ -6,14 +6,16 @@
 
 namespace CASM {
 
-  struct DoFSpace;
+  class ConfigEnumInput;
+  class DoFSpace;
   class Log;
 
   /// Print DoFSpace information
   template<typename PermuteIteratorIt>
   void print_dof_space(Log &log,
-                       std::string const &name,
                        DoFSpace const &dof_space,
+                       std::string const &identifier,
+                       ConfigEnumInput const &input_state,
                        PermuteIteratorIt permute_begin,
                        PermuteIteratorIt permute_end,
                        bool sym_axes,

--- a/include/casm/app/io/file/clex_io.hh
+++ b/include/casm/app/io/file/clex_io.hh
@@ -1,0 +1,24 @@
+#ifndef CASM_app_clex_file_io
+#define CASM_app_clex_file_io
+
+namespace CASM {
+
+  class Configuration;
+  class DirectoryStructure;
+  class Supercell;
+
+  /// Write supercell "LAT" file (supercell lattice vectors as column vectors) to standard location
+  void write_lat(Supercell const &supercell, DirectoryStructure const &dir);
+
+  /// Write configuration "POS" file (VASP POSCAR) to standard location
+  void write_pos(Configuration const &configuration, DirectoryStructure const &dir);
+
+  /// Write configuration "structure.json" file (structure that results from appling DoF) to standard location
+  void write_structure_json(Configuration const &configuration, DirectoryStructure const &dir);
+
+  /// Write configuration "config.json" file (DoF values in standard basis) to standard location
+  void write_config_json(Configuration const &configuration, DirectoryStructure const &dir);
+
+}
+
+#endif

--- a/include/casm/app/query/QueryIO.hh
+++ b/include/casm/app/query/QueryIO.hh
@@ -1,0 +1,59 @@
+#ifndef CASM_app_query_QueryIO
+#define CASM_app_query_QueryIO
+
+namespace CASM {
+
+  class PermuteIterator;
+  template<typename ValueType>
+  struct QueryData;
+
+  namespace adapter {
+
+    template <typename ToType, typename FromType> struct Adapter;
+
+    template<typename DataObject>
+    struct Adapter<DataObject, QueryData<DataObject>> {
+      DataObject const &operator()(QueryData<DataObject> const &adaptable) const;
+    };
+
+  }
+
+  /// Collect information during `enumerate_configurations` function for optional output
+  template<typename ValueType>
+  struct QueryData {
+
+    QueryData(PrimClex const &_primclex,
+              ValueType const &_value,
+              bool _include_equivalents = false,
+              Index _equivalent_index = 0,
+              PermuteIterator const *_permute_it = nullptr);
+
+    PrimClex const &primclex;
+    ValueType const &value;
+    bool include_equivalents;
+    Index equivalent_index;
+    PermuteIterator const *permute_it;
+  };
+
+  namespace QueryIO {
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> equivalent_index();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op();
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc();
+
+    template <typename QueryDataType>
+    Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation();
+
+  }
+
+}
+
+#endif

--- a/include/casm/app/query/QueryIO.hh
+++ b/include/casm/app/query/QueryIO.hh
@@ -18,7 +18,7 @@ namespace CASM {
 
   }
 
-  /// Collect information during `enumerate_configurations` function for optional output
+  /// Data structure to collect value (Supercell, Configuration, etc.) and data for query formatting
   template<typename ValueType>
   struct QueryData {
 
@@ -28,27 +28,41 @@ namespace CASM {
               Index _equivalent_index = 0,
               PermuteIterator const *_permute_it = nullptr);
 
+    /// Provides access to project data
     PrimClex const &primclex;
+
+    /// The object under consideration (Supercell, Configuration, etc.)
     ValueType const &value;
+
+    /// True if non-canonical equivalents are also being queried
     bool include_equivalents;
+
+    /// Index incremented for each non-canonical equivalent
     Index equivalent_index;
+
+    /// Permutation that transforms the canonical form to the current non-canonical equivalent value
     PermuteIterator const *permute_it;
   };
 
   namespace QueryIO {
 
+    /// Index incremented for each non-canonical equivalent (QueryDataType::equivalent_index)
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> equivalent_index();
 
+    /// Index of permute factor group operation in the supercell factor group (QueryDataType::permute_it->factor_group_index())
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op();
 
+    /// Index of permute factor group operation in the prim factor group (QueryDataType::permute_it->prim_factor_group_index())
     template <typename QueryDataType>
     GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op();
 
+    /// Description of permute factor group operation in the prim factor group
     template <typename QueryDataType>
     GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc();
 
+    /// Permute translation operation as (i, j, k) multiples of the prim lattice vectors
     template <typename QueryDataType>
     Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation();
 

--- a/include/casm/app/query/QueryIO_impl.hh
+++ b/include/casm/app/query/QueryIO_impl.hh
@@ -1,0 +1,98 @@
+#ifndef CASM_app_query_QueryIO_impl
+#define CASM_app_query_QueryIO_impl
+
+#include "casm/app/query/QueryIO.hh"
+#include "casm/casm_io/dataformatter/DatumFormatterAdapter.hh"
+#include "casm/crystallography/Structure.hh"
+#include "casm/symmetry/PermuteIterator.hh"
+#include "casm/symmetry/SupercellSymInfo_impl.hh"
+
+namespace CASM {
+
+  namespace adapter {
+
+    template<typename DataObject>
+    DataObject const &Adapter<DataObject, QueryData<DataObject>>::operator()(
+    QueryData<DataObject> const &adaptable) const {
+      return adaptable.value;
+    }
+
+  }
+
+  template<typename ValueType>
+  QueryData<ValueType>::QueryData(PrimClex const &_primclex,
+                                  ValueType const &_value,
+                                  bool _include_equivalents,
+                                  Index _equivalent_index,
+                                  PermuteIterator const *_permute_it):
+    primclex(_primclex),
+    value(_value),
+    include_equivalents(_include_equivalents),
+    equivalent_index(_equivalent_index),
+    permute_it(_permute_it) {}
+
+  namespace QueryIO {
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> equivalent_index() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "equivalent_index",
+               "Index that counts over distinct symmetrically equivalent objects",
+      [](QueryDataType const & data) -> Index {
+        return data.equivalent_index;
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "permute_scel_factor_group_op",
+               "Factor group operation (applied before translation operation) of the permutation "
+               "that generated the equivalent object, as its index into the prim factor group",
+      [](QueryDataType const & data) -> Index {
+        return data.permute_it->factor_group_index();
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op() {
+      return GenericDatumFormatter<Index, QueryDataType>(
+               "permute_factor_group_op",
+               "Factor group operation (applied before translation operation) of the permutation "
+               "that generated the equivalent object, as its index into the prim factor group",
+      [](QueryDataType const & data) -> Index {
+        return data.permute_it->prim_factor_group_index();
+      });
+    }
+
+    template <typename QueryDataType>
+    GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc() {
+      return GenericDatumFormatter<std::string, QueryDataType>(
+               "permute_factor_group_op_desc",
+               "Description of prim factor group operation that generated equivalent object",
+      [](QueryDataType const & data) -> std::string {
+
+        auto const &factor_group_op = data.permute_it->factor_group()[data.permute_it->factor_group_index()];
+        auto const &lattice = data.primclex.prim().lattice();
+        std::stringstream ss;
+        ss << "'" << brief_description(factor_group_op, lattice) << "'";
+        return ss.str();
+      });
+    }
+
+    template <typename QueryDataType>
+    Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation() {
+      return Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType>(
+               "permute_translation",
+               "Translation (applied after factor group operation) of the permutation that generated "
+               "the equivalent object, as a linear combination of the lattice vectors",
+      [](QueryDataType const & data) -> Eigen::Vector3l {
+        return data.permute_it->sym_info().unitcell_index_converter()(data.permute_it->translation_index());
+      });
+    }
+
+  }
+
+}
+
+#endif

--- a/include/casm/app/query/QueryIO_impl.hh
+++ b/include/casm/app/query/QueryIO_impl.hh
@@ -37,7 +37,8 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> equivalent_index() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "equivalent_index",
-               "Index that counts over distinct symmetrically equivalent objects",
+               "[--include-equivalents query only] Index that counts over distinct symmetrically "
+               "equivalent objects",
       [](QueryDataType const & data) -> Index {
         return data.equivalent_index;
       });
@@ -47,8 +48,9 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> permute_scel_factor_group_op() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "permute_scel_factor_group_op",
-               "Factor group operation (applied before translation operation) of the permutation "
-               "that generated the equivalent object, as its index into the prim factor group",
+               "[--include-equivalents query only] Factor group operation (applied before "
+               "translation operation) of the permutation that generated the equivalent object, as "
+               "its index into the supercell factor group",
       [](QueryDataType const & data) -> Index {
         return data.permute_it->factor_group_index();
       });
@@ -58,8 +60,9 @@ namespace CASM {
     GenericDatumFormatter<Index, QueryDataType> permute_factor_group_op() {
       return GenericDatumFormatter<Index, QueryDataType>(
                "permute_factor_group_op",
-               "Factor group operation (applied before translation operation) of the permutation "
-               "that generated the equivalent object, as its index into the prim factor group",
+               "[--include-equivalents query only] Factor group operation (applied before "
+               "translation operation) of the permutation that generated the equivalent object, as "
+               "its index into the prim factor group",
       [](QueryDataType const & data) -> Index {
         return data.permute_it->prim_factor_group_index();
       });
@@ -69,7 +72,8 @@ namespace CASM {
     GenericDatumFormatter<std::string, QueryDataType> permute_factor_group_op_desc() {
       return GenericDatumFormatter<std::string, QueryDataType>(
                "permute_factor_group_op_desc",
-               "Description of prim factor group operation that generated equivalent object",
+               "[--include-equivalents query only] Description of prim factor group operation that "
+               "generated the equivalent object.",
       [](QueryDataType const & data) -> std::string {
 
         auto const &factor_group_op = data.permute_it->factor_group()[data.permute_it->factor_group_index()];
@@ -84,8 +88,9 @@ namespace CASM {
     Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType> permute_translation() {
       return Generic1DDatumFormatter<Eigen::Vector3l, QueryDataType>(
                "permute_translation",
-               "Translation (applied after factor group operation) of the permutation that generated "
-               "the equivalent object, as a linear combination of the lattice vectors",
+               "[--include-equivalents query only] Translation (applied after factor "
+               "group operation) of the permutation that generated the equivalent object, as "
+               "(i, j, k) multiples of the prim lattice vectors.",
       [](QueryDataType const & data) -> Eigen::Vector3l {
         return data.permute_it->sym_info().unitcell_index_converter()(data.permute_it->translation_index());
       });

--- a/include/casm/app/sym/dof_space_analysis.hh
+++ b/include/casm/app/sym/dof_space_analysis.hh
@@ -6,6 +6,7 @@
 namespace CASM {
 
   class APICommandBase;
+  class PrimClex;
   class jsonParser;
 
   /// Describe DoF space analysis input

--- a/include/casm/casm_io/dataformatter/DataFormatterDecl.hh
+++ b/include/casm/casm_io/dataformatter/DataFormatterDecl.hh
@@ -212,6 +212,15 @@ namespace CASM {
   template<typename DataObject>
   MatrixXdAttributeDictionary<DataObject> make_matrixxd_dictionary();
 
+
+  class jsonParser;
+  /// \brief Template to be specialized for constructing dictionaries for particular DataObject
+  ///
+  /// \ingroup DataFormatter
+  ///
+  template<typename DataObject>
+  DataFormatterDictionary<DataObject, BaseValueFormatter<jsonParser, DataObject>> make_json_dictionary();
+
 }
 
 #endif

--- a/include/casm/casm_io/dataformatter/DataFormatterTools.hh
+++ b/include/casm/casm_io/dataformatter/DataFormatterTools.hh
@@ -1169,7 +1169,8 @@ namespace CASM {
       make_scalar_dictionary<DataObject>(),
       make_vectorxi_dictionary<DataObject>(),
       make_vectorxd_dictionary<DataObject>(),
-      make_matrixxd_dictionary<DataObject>()
+      make_matrixxd_dictionary<DataObject>(),
+      make_json_dictionary<DataObject>()
     );
 
     return dict;

--- a/include/casm/casm_io/dataformatter/DataStream.hh
+++ b/include/casm/casm_io/dataformatter/DataStream.hh
@@ -6,6 +6,8 @@
 #include <functional>
 namespace CASM {
 
+  class jsonParser;
+
   /// \ingroup DataFormatter
   ///
   class DataStream {
@@ -52,6 +54,10 @@ namespace CASM {
       return *this;
     }
     */
+
+    virtual DataStream &operator<<(jsonParser const &) {
+      throw std::runtime_error("Error in DataStream input: JSON may not be input to DataStream");
+    }
 
     DataStream &operator<<(DataStream & (*F)(DataStream &)) {
       return F(*this);

--- a/include/casm/casm_io/json/optional.hh
+++ b/include/casm/casm_io/json/optional.hh
@@ -1,0 +1,50 @@
+#ifndef CASM_json_optional
+#define CASM_json_optional
+
+namespace CASM {
+
+  template<typename T>
+  struct jsonConstructor;
+  class jsonParser;
+
+  template<typename T, typename... Args>
+  jsonParser &to_json(std::optional<T> const &value, jsonParser &json) {
+    if(value.has_value()) {
+      to_json(value.value(), json);
+    }
+    else {
+      json.put_null();
+    }
+    return json;
+  }
+
+  template<typename T, typename... Args>
+  void from_json(std::optional<T> &value, jsonParser const &json, Args &&... args) {
+    if(json.is_null()) {
+      value.reset();
+    }
+    else {
+      value = jsonConstructor<T>::from_json(json, std::forward<Args>(args)...);
+    }
+  }
+
+  /// Helper struct for constructing std::optional<T> objects
+  template<typename T>
+  struct jsonConstructor<std::optional<T>> {
+
+    /// \brief Default from_json is equivalent to \code CASM::from_json<ReturnType>(json) \endcode
+    template<typename... Args>
+    static std::optional<T> from_json(jsonParser const &json, Args &&... args) {
+      if(json.is_null()) {
+        return std::nullopt;
+      }
+      else {
+        std::optional<T> value = jsonConstructor<T>::from_json(json, std::forward<Args>(args)...);
+        return value;
+      }
+    }
+  };
+
+}
+
+#endif

--- a/include/casm/clex/ConfigDoFTools.hh
+++ b/include/casm/clex/ConfigDoFTools.hh
@@ -1,0 +1,16 @@
+#ifndef CASM_clex_ConfigDoFTools
+#define CASM_clex_ConfigDoFTools
+
+#include "casm/global/definitions.hh"
+
+namespace CASM {
+
+  class ConfigDoF;
+  class Structure;
+
+  /// Construct zero-valued ConfigDoF
+  ConfigDoF make_configdof(Structure const &prim, Index volume);
+
+}
+
+#endif

--- a/include/casm/clex/ConfigDoFValues.hh
+++ b/include/casm/clex/ConfigDoFValues.hh
@@ -135,18 +135,21 @@ namespace CASM {
 
     }
 
-    /// DoF vector representation size
-    Index dim() const {
-      return m_vals.rows();
-    }
+    // /// DoF vector representation size
+    // Index dim() const {
+    //   return m_vals.rows(); // this is the standard basis dimension, not the prim basis dimension
+    // }
 
     /// Access site DoF values (prim DoF basis, matrix representing all sites)
     ///
     /// Notes:
-    /// - Matrix of size rows=dim(), cols=n_vol()*n_sublat(),
+    /// - Matrix of size rows=standard basis dimension (this->info()[b].basis().rows()), cols=n_vol()*n_sublat(),
     /// - Each column represents a site DoF value in the prim DoF basis
-    /// - The prim DoF basis can be accessed by `this->info()[b]`, where `b` is the sublattice index,
+    /// - The prim DoF basis can be accessed by `this->info()[b].basis()`, where `b` is the sublattice index,
     ///   `b = column_index / this->n_vol()`
+    /// - If the prim DoF basis dimension (this->info()[b].basis().cols()) is less than the standard
+    ///   DoF basis dimension, the matrix includes blocks of zeros for the corresponding
+    ///   sublattice.
     Reference values() {
       return m_vals;
     }
@@ -184,11 +187,18 @@ namespace CASM {
     }
 
     /// Access site DoF value (prim DoF basis, vector associated with a single site)
+    ///
+    /// Note:
+    /// - If the prim DoF basis dimension < standard DoF basis dimension, this includes a tail of
+    ///   zeros (for rows >= this->info()[b].dim()) that should not be modified.
     SiteReference site_value(Index l) {
       return m_vals.col(l);
     }
 
     /// Const access site DoF value (prim DoF basis, vector associated with a single site)
+    /// Note:
+    /// - If the prim DoF basis dimension < standard DoF basis dimension, this includes a tail of
+    ///   zeros (for rows >= this->info()[b].dim()).
     ConstSiteReference site_value(Index l) const {
       return m_vals.col(l);
     }

--- a/include/casm/clex/ConfigIO.hh
+++ b/include/casm/clex/ConfigIO.hh
@@ -20,6 +20,7 @@ namespace CASM {
   class Configuration;
   template<typename DataObject>
   class Norm;
+  class jsonParser;
 
   /**  \addtogroup ConfigIO
        @{
@@ -447,6 +448,13 @@ namespace CASM {
 
     ConfigIO::GenericConfigFormatter<double> relaxed_magmom_per_species();
 
+    ConfigIO::GenericConfigFormatter<jsonParser> config();
+
+    ConfigIO::GenericConfigFormatter<jsonParser> configdof();
+
+    ConfigIO::GenericConfigFormatter<jsonParser> properties();
+
+    ConfigIO::GenericConfigFormatter<std::string> poscar();
   }
 
   template<>

--- a/include/casm/clex/Configuration.hh
+++ b/include/casm/clex/Configuration.hh
@@ -445,21 +445,6 @@ namespace CASM {
   };
 
 
-  template<>
-  struct jsonConstructor<Configuration> {
-
-    Configuration from_json(
-      const jsonParser &json,
-      const PrimClex &primclex,
-      const std::string &configname);
-
-    Configuration from_json(
-      const jsonParser &json,
-      const Supercell &scel,
-      const std::string &id);
-  };
-
-
   /// \brief Holds results of Configuration::insert
   ///
   /// - 'canonical' refers to the canonical form of the Configuration in it's
@@ -506,19 +491,6 @@ namespace CASM {
     Eigen::Matrix3i transf_mat;
   };
 
-
-
-  /// \brief Write the POS file to string
-  std::string pos_string(Configuration const &_config);
-
-  /// Write the POS file to pos_path
-  void write_pos(Configuration const &_config);
-
-  /// \brief Write the config.json file to string
-  std::string config_json_string(Configuration const &_config);
-
-  /// Write the config.json file to config_json_path
-  void write_config_json(Configuration const &_config);
 
   /// \brief Returns the sub-configuration that fills a particular Supercell
   ///
@@ -648,8 +620,6 @@ namespace CASM {
 
   bool has_relaxed_mag_basis(const Configuration &_config);
 
-
-  std::ostream &operator<<(std::ostream &sout, const Configuration &c);
 
   /// \brief Returns correlations using 'clexulator'. Supercell needs a correctly populated neighbor list.
   Eigen::VectorXd correlations(const ConfigDoF &configdof, const Supercell &scel, Clexulator const &clexulator);

--- a/include/casm/clex/HasCanonicalForm_impl.hh
+++ b/include/casm/clex/HasCanonicalForm_impl.hh
@@ -314,7 +314,29 @@ namespace CASM {
   template<typename Base>
   template<typename PermuteIteratorIt>
   PermuteIterator ConfigCanonicalForm<Base>::from_canonical(PermuteIteratorIt begin, PermuteIteratorIt end) const {
-    return to_canonical(begin, end).inverse();
+
+    // simplest version: use the inverse of the first element that results in the canonical form
+    // return to_canonical(begin, end).inverse();
+
+    // alternate version: the lowest index element that transforms canonical form to this
+    auto less = derived().less();
+    auto _to_canonical = begin;
+    auto _from_canonical = _to_canonical.inverse();
+    for(auto it = begin; it < end; ++it) {
+      if(less(_to_canonical, it)) {
+        _to_canonical = it;
+        _from_canonical = _to_canonical.inverse();
+      }
+      // other permutations that result in canonical config may have a lower index inverse
+      else if(!less(it, _to_canonical)) {
+        auto it_inv = it.inverse();
+        if(it_inv < _from_canonical) {
+          _from_canonical = it_inv;
+        }
+      }
+    }
+    return _from_canonical;
+
   }
 
   template<typename Base>

--- a/include/casm/clex/SimpleStructureTools.hh
+++ b/include/casm/clex/SimpleStructureTools.hh
@@ -1,89 +1,73 @@
 #ifndef CLEX_SIMPLESTRUCTURETOOLS_HH
 #define CLEX_SIMPLESTRUCTURETOOLS_HH
 
-#include "casm/basis_set/DoFTraits.hh"
-#include <string>
+#include <set>
+#include <vector>
+#include "casm/crystallography/DoFDecl.hh"
+#include "casm/global/definitions.hh"
+
 namespace CASM {
-  class Supercell;
+
+  namespace xtal {
+    class SimpleStructure;
+  }
+
   class ConfigDoF;
   class Configuration;
   struct MappedProperties;
-
-  namespace DoFType {
-    class Traits;
-  }
-
-  namespace xtal {
-    class BasicStructure;
-  }
-
-  //TODO: What is this?
-  class TransformDirective {
-  public:
-
-    /// \brief consturct from transformation or DoF type name
-    TransformDirective(std::string const &_name);
-
-    /// \brief Name of DoFType or transformation
-    std::string const &name() const {
-      return m_name;
-    }
-
-    /// \brief Compare with _other TransformDirective. Returns true if this TransformDirective has precedence
-    bool operator<(TransformDirective const &_other) const;
-
-    /// \brief Applies transformation to _struc using information contained in _config
-    void transform(ConfigDoF const  &_config, xtal::BasicStructure const &_reference, SimpleStructure &_struc) const;
-
-  private:
-    /// \brief Build m_before object by recursively traversing DoF dependencies
-    void _accumulate_before(std::set<std::string>const &_queue, std::set<std::string> &_result) const;
-
-    /// \brief Build m_after object by recursively traversing DoF dependencies
-    void _accumulate_after(std::set<std::string>const &_queue, std::set<std::string> &_result) const;
-
-    std::string m_name;
-    std::set<std::string> m_before;
-    std::set<std::string> m_after;
-
-    DoFType::Traits const *m_traits_ptr;
-  };
-
-  /// \brief Construct SimpleStructure from Configuration
-  /// @param _config Configuration used as source data
-  /// @param _which_dofs List of DoF type-names that specify which DoF values to utilize from _config when building the result
-  ///        if empty, all DoFs are used. To exclude all DoFs from conversion, pass _which_dofs={"none"}
-  /// @param relaxed flag specifying to use relaxed coordinates and parameters (if true) or to only use the imposed DoFs (if false)
-  SimpleStructure make_simple_structure(Configuration const &_config,
-                                        std::vector<DoFKey> const &_which_dofs = {},
-                                        bool relaxed = false);
+  class Supercell;
 
   /// \brief Construct from ConfigDoF _dof belonging to provided Supercell _scel
   /// @param _which_dofs List of DoF type-names that specify which DoF values to utilize from _config when building the result
   ///        if empty, all DoFs are used. To exclude all DoFs from conversion, pass _which_dofs={"none"}
-  SimpleStructure make_simple_structure(Supercell const &_scel,
-                                        ConfigDoF const &_dof,
-                                        std::vector<DoFKey> const &_which_dofs = {});
+  xtal::SimpleStructure make_simple_structure(Supercell const &_scel,
+                                              ConfigDoF const &_dof,
+                                              std::vector<DoFKey> const &_which_dofs = {});
+
+  /// \brief Construct SimpleStructure from Configuration
+  /// @param _config Configuration used as source data
+  /// @param _which_dofs List of DoF type-names that specify which DoF values to utilize from
+  ///        _config when building the result. If empty, all DoFs are used. To exclude all DoFs from
+  ///        conversion, pass _which_dofs={"none"}.
+  /// @param relaxed Flag specifying to use relaxed coordinates and parameters (if true) or to only
+  ///        use the imposed DoFs (if false).
+  ///
+  /// Note:
+  /// - If `(relaxed==true && is_calculated(_config)`:
+  ///   - MappedProperties from `_config.calc_properties()` are applied.
+  ///   - Relaxed coordinates are obtained from `_config.calc_properties().site.at("coordinate")`
+  ///   - Relaxed lattice vectors  are obtained from `_config.calc_properties().global.at("latvec")`
+  ///   - It is expected, but not checked, that there exist no DoF whose application further affects
+  ///     the coordinates or lattice vectors
+  /// - Otherwise: no MappedProperties are applied.
+  xtal::SimpleStructure make_simple_structure(Configuration const &_config,
+                                              std::vector<DoFKey> const &_which_dofs = {},
+                                              bool relaxed = false);
 
   /// \brief Construct from ConfigDoF _dof belonging to provided Supercell _scel and using calculated properties
   /// @param _props Record of calculated properties to use during conversion
   /// @param relaxed flag specifying to use _props argument during conversion (if true)
-  SimpleStructure make_simple_structure(Supercell const &_scel,
-                                        ConfigDoF const &_dof,
-                                        MappedProperties const &_props,
-                                        std::vector<DoFKey> const &_which_dofs = {},
-                                        bool relaxed = false);
+  ///
+  /// Note:
+  /// - If relaxed==true:
+  ///   - Relaxed coordinates are obtained from `_config.calc_properties().site.at("coordinate")`
+  ///   - Relaxed lattice vectors  are obtained from `_config.calc_properties().global.at("latvec")`
+  ///   - It is expected, but not checked, that there exist no DoF whose application further affects
+  ///     the coordinates or lattice vectors.
+  /// - Otherwise: no MappedProperties are applied.
+  xtal::SimpleStructure make_simple_structure(Supercell const &_scel,
+                                              ConfigDoF const &_dof,
+                                              MappedProperties const &_props,
+                                              std::vector<DoFKey> const &_which_dofs = {},
+                                              bool relaxed = false);
 
   /// \brief Determine which sites of a Configuration can host each atom of a SimpleStructure
   /// result[i] is set of site indices in @param _config that can host atom 'i' of @param sstruc
-  std::vector<std::set<Index> > atom_site_compatibility(SimpleStructure const &sstruc, Configuration const &_config);
+  std::vector<std::set<Index> > atom_site_compatibility(xtal::SimpleStructure const &sstruc, Configuration const &_config);
 
   /// \brief Determine which sites of a Configuration can host each molecule of a SimpleStructure
   /// result[i] is set of site indices in @param _config that can host molecule 'i' of @param sstruc
-  std::vector<std::set<Index> > mol_site_compatibility(SimpleStructure const &sstruc, Configuration const &_config);
-
-  /// \brief Imposes DoF values from ConfigDoF _config onto *this, using using any necessary information contained in _reference
-  void _apply_dofs(SimpleStructure &_sstruc, ConfigDoF const &_config, BasicStructure const &_reference, std::vector<DoFKey> which_dofs);
+  std::vector<std::set<Index> > mol_site_compatibility(xtal::SimpleStructure const &sstruc, Configuration const &_config);
 
 }
 

--- a/include/casm/clex/Supercell.hh
+++ b/include/casm/clex/Supercell.hh
@@ -182,19 +182,34 @@ namespace CASM {
 
   };
 
-  void write_pos(Supercell const &_scel);
+  /// Make the supercell name from a Superlattice
+  std::string make_supercell_name(
+    Structure const &prim,
+    xtal::Superlattice const &superlattice);
 
-  std::string pos_string(Supercell const &_scel);
+  /// Make the canonical supercell name from a Superlattice
+  std::string make_canonical_supercell_name(
+    Structure const &prim,
+    xtal::Superlattice const &superlattice);
 
-  /// \brief Get canonical supercell from name. If not yet in database, construct and insert.
-  const Supercell &make_supercell(const PrimClex &primclex, std::string name);
+  /// Construct a Superlattice from the supercell name
+  xtal::Superlattice make_superlattice_from_supercell_name(
+    Structure const &prim,
+    std::string supercell_name);
 
-  /// \brief Construct non-canonical supercell from name. Uses equivalent niggli lattice.
-  std::shared_ptr<Supercell> make_shared_supercell(const PrimClex &primclex, std::string name);
-
+  /// Apply symmetry operation to Supercell
   Supercell &apply(const SymOp &op, Supercell &scel);
 
+  /// Copy and apply symmetry operation to Supercell
   Supercell copy_apply(const SymOp &op, const Supercell &scel);
+
+
+
+  // --- The following are deprecated ----
+
+  const Supercell &make_supercell(const PrimClex &primclex, std::string name);
+
+  std::shared_ptr<Supercell> make_shared_supercell(const PrimClex &primclex, std::string name);
 
   Eigen::Matrix3l transf_mat(const Lattice &prim_lat, const Lattice &super_lat);
 

--- a/include/casm/clex/io/json/ConfigDoF_json_io.hh
+++ b/include/casm/clex/io/json/ConfigDoF_json_io.hh
@@ -33,26 +33,19 @@ namespace CASM {
   struct jsonMake<ConfigDoF> {
 
     static std::unique_ptr<ConfigDoF> make_from_json(const jsonParser &json,
-                                                     Structure const &structure);
+                                                     Structure const &prim);
   };
 
   template<>
   struct jsonConstructor<ConfigDoF> {
 
-    // static ConfigDoF from_json(const jsonParser &json,
-    //                            Index NB,
-    //                            std::map<DoFKey, DoFSetInfo> const &global_info,
-    //                            std::map<DoFKey, std::vector<DoFSetInfo> > const &local_info,
-    //                            std::vector<SymGroupRepID> const &_occ_symrep_IDs,
-    //                            double _tol);
-
-    static ConfigDoF from_json(jsonParser const &json, Structure const &structure);
+    static ConfigDoF from_json(jsonParser const &json, Structure const &prim);
 
   };
 
-  jsonParser &to_json(const ConfigDoF &value, jsonParser &json);
+  jsonParser &to_json(const ConfigDoF &configdof, jsonParser &json);
 
-  void from_json(ConfigDoF &value, const jsonParser &json);
+  void from_json(ConfigDoF &configdof, const jsonParser &json);
 
 }
 

--- a/include/casm/clex/io/json/Configuration_json_io.hh
+++ b/include/casm/clex/io/json/Configuration_json_io.hh
@@ -1,0 +1,40 @@
+#ifndef CASM_clex_Configuration_json_io
+#define CASM_clex_Configuration_json_io
+
+#include <string>
+
+namespace CASM {
+
+  class PrimClex;
+  class Supercell;
+  class jsonParser;
+
+  template<typename T> struct jsonConstructor;
+
+  template<>
+  struct jsonConstructor<Configuration> {
+
+    /// Read Configuration from JSON
+    static Configuration from_json(
+      jsonParser const &json,
+      std::shared_ptr<const Structure> const &shared_prim);
+  };
+
+  template<>
+  struct jsonMake<Configuration> {
+
+    /// Read Configuration from JSON
+    static std::unique_ptr<Configuration> make_from_json(
+      jsonParser const &json,
+      std::shared_ptr<const Structure> const &shared_prim);
+  };
+
+  /// Insert Configuration to JSON
+  jsonParser &to_json(Configuration const &configuration, jsonParser &json);
+
+  /// Read Configuration from JSON
+  void from_json(Configuration &configuration, jsonParser const &json);
+
+}
+
+#endif

--- a/include/casm/clex/io/stream/Configuration_stream_io.hh
+++ b/include/casm/clex/io/stream/Configuration_stream_io.hh
@@ -1,0 +1,16 @@
+#ifndef CASM_clex_Configuration_stream_io
+#define CASM_clex_Configuration_stream_io
+
+#include <iostream>
+
+namespace CASM {
+
+  /// Print Configuration as a VASP POSCAR
+  ///
+  /// Note: This makes use of VaspIO::PrintPOSCAR, which can be used directly for additional
+  ///       formatting options.
+  void print_poscar(Configuration const &configuration, std::ostream &sout);
+
+}
+
+#endif

--- a/include/casm/enumerator/DoFSpace.hh
+++ b/include/casm/enumerator/DoFSpace.hh
@@ -5,51 +5,211 @@
 #include "casm/enumerator/ConfigEnumInput.hh"
 
 namespace CASM {
+
   struct VectorSpaceSymReport;
 
-  class DoFSpaceSymReport;
+  /// DoFSpace
+  ///
+  /// The DoFSpace class is used to specify a particular degree of freedom space. DoFSpace have:
+  ///   - shared_prim (std::shared_ptr<Structure const>): The prim structure
+  ///   - dof_key (DoFKey): A string indicating which DoF type (e.g., "disp", "Hstrain", "occ")
+  ///   - transformation_matrix_to_super (std::optional<Eigen::Matrix3l>): Specifies the supercell
+  ///     for a local DoF space. Has value for local DoF.
+  ///   - sites (std::optional<std::set<Index>>): The sites included in a local DoF space. Has value
+  ///     for local DoF.
+  ///   - basis (Eigen::MatrixXd): Allows specifying a subspace of the space determined from
+  ///     dof_key, and for local DoF, transformation_matrix_to_super and sites. Examples:
+  ///
+  ///       For dof_key=="disp", and sites.value().size()==4 (any transformation_matrix_to_super):
+  ///         The default DoF space has dimension 12 corresponding to (x,y,z) for each of the 4 sites.
+  ///         Then, basis is a matrix with 12 rows and 12 or fewer columns.
+  ///
+  ///       For dof_key=="occ", and sites().value().size()==4 (any transformation_matrix_to_super),
+  ///       with the particular sites selected having allowed occupations ["A", "B"],
+  ///       ["A", "B", "C"], ["A, B"], and ["A", "B", "C"] :
+  ///         The default DoF space has dimension 10 = 2 + 3 + 2 + 3.
+  ///         Then, basis is a matrix with 10 rows and 10 or fewer columns.
+  ///
+  ///       For dof_key=="GLstrain":
+  ///         The default DoF space has dimension 6 for the six independent GLstrain components.
+  ///         Then, basis is a matrix with 6 rows and 6 or fewer columns.
+  //
+  ///     By default, basis is the full DoF space (identity matrix with dimensions matching
+  ///     the full space for the particular combination of config_region and dof_key).
+  class DoFSpace {
+  public:
 
-  ///\brief Compositiong of enumeration environment (as ConfigEnumInput), DoF type (as DoFKey),
-  // and vector subpsace. This simplifies generation of a VectorSpaceSymReport for a range of inputs
-  struct DoFSpace {
+    DoFSpace(
+      std::shared_ptr<Structure const> const &_shared_prim,
+      DoFKey const &_dof_key,
+      std::optional<Eigen::Matrix3l> const &_transformation_matrix_to_super = std::nullopt,
+      std::optional<std::set<Index>> const &_sites = std::nullopt,
+      std::optional<Eigen::MatrixXd> const &_basis = std::nullopt);
 
-    /// Definition of Configuration region for which enumeration/analysis is to be performed
-    ConfigEnumInput config_region;
+    /// Shared prim structure
+    std::shared_ptr<Structure const> const &shared_prim() const;
 
     /// Type of degree of freedom that is under consideration (e.g., "disp", "Hstrain", "occ")
-    DoFKey dof_key;
+    DoFKey const &dof_key() const;
 
-    /// Columns of dof_subspace span a subspace of allowed DoF values in configuration
-    /// Number of rows must equal dimension of intrinsic DoF vector space (e.g., 3*N for displacement)
-    /// Number columns must be less than or equal to number of rows
-    Eigen::MatrixXd dof_subspace;
+    /// Specifies the supercell for a local DoF space. Has value for local DoF.
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super() const;
 
-    /// Construct with ConfigEnuminput, DoFKey (which specifies DoF type), and subspace matrix
-    /// Constructing with Supercell or Configuration is allowed via implicit conversiont to ConfigEnumInput.
-    /// By default, _dof_subspace matrix (i.e., an empty matrix) results in dof_subspace being initialized to
-    /// Identity matrix having same dimension as complete DoF vector space of the provided ConfigEnumInput.
-    /// Columns of _dof_subspace are vectors in the DoF vector space of the provided ConfigEnumInput, and so
-    /// the number of rows of _dof_subspace is determined by the ConfigEnumInput and DoF type.
-    /// The rank of _dof_subspace must be equal to its number of columns (i.e., columns are linearly independent).
-    DoFSpace(ConfigEnumInput _config_region,
-             DoFKey _dof_key,
-             Eigen::MatrixXd _dof_subspace = Eigen::MatrixXd());
+    /// The sites included in a local DoF space. Has value for local DoF.
+    std::optional<std::set<Index>> const &sites() const;
+
+    /// The DoF space basis, as a column vector matrix. May be a subspace (cols <= rows).
+    Eigen::MatrixXd const &basis() const;
+
+    /// The DoF space dimension (equal to number of rows in basis).
+    Index dim() const;
+
+    /// The DoF subspace dimension (equal to number of columns in basis).
+    Index subspace_dim() const;
+
+    /// The inverse of the DoF space basis.
+    Eigen::MatrixXd const &basis_inverse() const;
+
+    /// Names the DoF corresponding to each dimension (row) of the basis
+    std::vector<std::string> const &axis_glossary() const;
+
+    /// The supercell site_index corresponding to each dimension (row) of the basis. Has value for
+    /// local DoF.
+    ///
+    /// Note:
+    /// - For continuous DoF this gives the column index in `ConfigDoF.local_dof(dof_key).values()`
+    ///   corresponding to each row in the DoFSpace basis.
+    /// - For "occ" DoF this gives the site index in `ConfigDoF.occupation()` corresponding to
+    ///   each row in the DoFSpace basis.
+    std::optional<std::vector<Index>> const &axis_site_index() const;
+
+    /// The local DoF site DoFSet component index corresponding to each dimension (row) of the
+    /// basis. Has value for local DoF.
+    ///
+    /// Note:
+    /// - For continuous DoF this gives the row index in `ConfigDoF.local_dof(dof_key).values()`
+    ///   corresponding to each row in the DoFSpace basis.
+    /// - For "occ" DoF this gives the index into `Site.occupant_dof()`, which is the value of
+    ///   of `ConfigDoF.occupation()[site_index]`.
+    std::optional<std::vector<Index>> const &axis_dof_component() const;
+
+
+  private:
+
+    /// Shared prim structure
+    std::shared_ptr<Structure const> m_shared_prim;
+
+    /// Type of degree of freedom that is under consideration (e.g., "disp", "Hstrain", "occ")
+    DoFKey m_dof_key;
+
+    /// Specifies the supercell for a local DoF space. Required for local DoF.
+    std::optional<Eigen::Matrix3l> m_transformation_matrix_to_super;
+
+    /// The sites included in a local DoF space. Required for local DoF.
+    std::optional<std::set<Index>> m_sites;
+
+    /// The DoF space basis, as a column vector matrix. May be a subspace (cols <= rows).
+    Eigen::MatrixXd m_basis;
+
+    /// The pseudoinverse of the DoF space basis.
+    Eigen::MatrixXd m_basis_inverse;
+
+    /// Names the DoF corresponding to each dimension (row) of the basis
+    std::vector<std::string> m_axis_glossary;
+
+    /// The supercell site_index corresponding to each dimension (row) of the basis. Has value for
+    /// local DoF.
+    ///
+    /// Note:
+    /// - For continuous DoF this gives the column index in `ConfigDoF.local_dof(dof_key).values()`
+    ///   corresponding to each row in the DoFSpace basis.
+    /// - For "occ" DoF this gives the site index in `ConfigDoF.occupation()` corresponding to
+    ///   each row in the DoFSpace basis.
+    std::optional<std::vector<Index>> m_axis_site_index;
+
+    /// The local DoF site DoFSet component index corresponding to each dimension (row) of the
+    /// basis. Has value for local DoF.
+    ///
+    /// Note:
+    /// - For continuous DoF this gives the row index in `ConfigDoF.local_dof(dof_key).values()`
+    ///   corresponding to each row in the DoFSpace basis.
+    /// - For "occ" DoF this gives the index into `Site.occupant_dof()`, which is the value of
+    ///   of `ConfigDoF.occupation()[site_index]`.
+    std::optional<std::vector<Index>> m_axis_dof_component;
 
   };
 
-  Index get_dof_space_dimension(DoFKey dof_key,
-                                Configuration const &configuration,
-                                std::set<Index> const &sites);
+  /// Return true if `dof_space` is valid for `config`
+  ///
+  /// Checks that:
+  /// - The prim are equivalent
+  /// - For local DoF, that the transformation_matrix_to_super are equivalent
+  bool is_valid_dof_space(Configuration const &config, DoFSpace const &dof_space);
 
-  std::vector<std::string> make_axis_glossary(DoFKey dof_key,
-                                              Configuration const &configuration,
-                                              std::set<Index> const &sites);
+  /// Throw if `!is_valid_dof_space(config, dof_space)`
+  void throw_if_invalid_dof_space(Configuration const &config, DoFSpace const &dof_space);
 
+  /// Return `config` DoF value as a coordinate in the DoFSpace basis
+  Eigen::VectorXd get_normal_coordinate(Configuration const &config, DoFSpace const &dof_space);
+
+  /// Set `config` DoF value from a coordinate in the DoFSpace basis
+  void set_dof_value(Configuration &config,
+                     DoFSpace const &dof_space,
+                     Eigen::VectorXd const &normal_coordinate);
+
+  /// Return dimension of DoFSpace
+  Index get_dof_space_dimension(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super = std::nullopt,
+    std::optional<std::set<Index>> const &sites = std::nullopt);
+
+  /// Make DoFSpace axis glossary
+  std::vector<std::string> make_dof_space_axis_glossary(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super = std::nullopt,
+    std::optional<std::set<Index>> const &sites = std::nullopt);
+
+  /// Make DoFSpace axis glossary, axis site index, and axis dof component
+  void make_dof_space_axis_info(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites,
+    std::vector<std::string> &axis_glossary,
+    std::optional<std::vector<Index>> &axis_site_index,
+    std::optional<std::vector<Index>> &axis_dof_component);
+
+  /// Make DoFSpace using `dof_key`, transformation matrix and sites from `input_state`, and `basis`
+  DoFSpace make_dof_space(
+    DoFKey dof_key,
+    ConfigEnumInput const &input_state,
+    std::optional<Eigen::MatrixXd> const &basis = std::nullopt);
+
+  /// Make VectorSpaceSymReport
   template<typename PermuteIteratorIt>
   VectorSpaceSymReport vector_space_sym_report(DoFSpace const &dof_space,
+                                               ConfigEnumInput const &input_state,
                                                PermuteIteratorIt group_begin,
                                                PermuteIteratorIt group_end,
-                                               bool calc_wedges = true);
+                                               bool calc_wedges = false);
+
+
+  /// Make DoFSpace with symmetry adapated basis
+  DoFSpace make_symmetry_adapted_dof_space(
+    DoFSpace const &dof_space,
+    ConfigEnumInput const &input_state,
+    std::vector<PermuteIterator> const &group,
+    bool calc_wedges,
+    std::optional<VectorSpaceSymReport> &symmetry_report);
+
+  class make_symmetry_adapted_dof_space_error : public std::runtime_error {
+  public:
+    make_symmetry_adapted_dof_space_error(std::string _what) :
+      std::runtime_error(_what) {}
+    virtual ~make_symmetry_adapted_dof_space_error() {}
+  };
 
 }
 

--- a/include/casm/enumerator/io/dof_space_analysis.hh
+++ b/include/casm/enumerator/io/dof_space_analysis.hh
@@ -1,0 +1,223 @@
+#ifndef CASM_enumerator_io_json_dof_space_analysis
+#define CASM_enumerator_io_json_dof_space_analysis
+
+#include "casm/global/definitions.hh"
+#include "casm/casm_io/json/jsonParser.hh"
+
+namespace CASM {
+
+  class ConfigEnumInput;
+  class DirectoryStructure;
+  class DoFSpace;
+  class SymGroup;
+  struct VectorSpaceSymReport;
+  class jsonParser;
+
+  namespace DoFSpaceIO {
+
+    class OutputImpl {
+    public:
+
+      /// Write symmetry groups (lattice point group, factor_group, crystal_point_group)
+      void write_symmetry(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        std::vector<PermuteIterator> const &group);
+
+      /// Write symmetry groups (lattice point group, factor_group, crystal_point_group)
+      ///
+      /// - lattice_point_group: point group of supercell lattice
+      /// - factor_group: subgroup of supercell factor group that keeps configuration DoF invariant
+      ///   and selected sites invariant
+      /// - crystal_point_group: factor_group excluding translations
+      virtual void write_symmetry(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        SymGroup const &lattice_point_group,
+        SymGroup const &factor_group,
+        SymGroup const &crystal_point_group) = 0;
+
+      // /// Write input state configuration
+      // virtual void write_config(
+      //   Index state_index,
+      //   std::string const &identifier,
+      //   ConfigEnumInput const &config_enum_input) = 0;
+
+      /// Write input state structure
+      virtual void write_structure(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) = 0;
+
+      /// Write dof space analysis
+      virtual void write_dof_space(
+        Index state_index,
+        DoFSpace const &dof_space,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        std::optional<VectorSpaceSymReport> const &sym_report) = 0;
+
+    };
+
+    class DirectoryOutput : public OutputImpl {
+    public:
+
+      using OutputImpl::write_symmetry;
+
+      void write_symmetry(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        SymGroup const &lattice_point_group,
+        SymGroup const &factor_group,
+        SymGroup const &crystal_point_group) override;
+
+      // void write_config(
+      //   Index state_index,
+      //   std::string const &identifier,
+      //   ConfigEnumInput const &config_enum_input) override;
+
+      void write_structure(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      void write_dof_space(
+        Index state_index,
+        DoFSpace const &dof_space,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        std::optional<VectorSpaceSymReport> const &sym_report) override;
+
+    private:
+
+      /// For SymmetryDirectoryOutput, configurations must exist in database and this will throw otherwise
+      virtual void _check_config(Index state_index,
+                                 std::string const &identifier,
+                                 ConfigEnumInput const &config_enum_input) = 0;
+
+      /// For SymmetryDirectoryOutput vs SequentialDirectoryOutput return output directory path
+      virtual fs::path _output_dir(Index state_index,
+                                   std::string const &identifier,
+                                   ConfigEnumInput const &config_enum_input) = 0;
+
+    };
+
+    /// Implementation that outputs to <casm_project>/symmetry/analysis/<configname>
+    class SymmetryDirectoryOutput : public DirectoryOutput {
+    public:
+      SymmetryDirectoryOutput(DirectoryStructure const &dir);
+
+    private:
+
+      /// For SymmetryDirectoryOutput, configurations must exist in database and this will throw otherwise
+      void _check_config(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      /// For SymmetryDirectoryOutput return output directory path in symmetry dir
+      fs::path _output_dir(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      DirectoryStructure const &m_dir;
+    };
+
+    /// Implementation that outputs to <output_dir>/dof_space/state.<index>
+    class SequentialDirectoryOutput : public DirectoryOutput {
+    public:
+      SequentialDirectoryOutput(fs::path output_dir);
+
+    private:
+
+      /// For SequentialDirectoryOutput, any input state is allowed
+      void _check_config(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      /// For SequentialDirectoryOutput return output directory path
+      fs::path _output_dir(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      fs::path m_output_dir;
+
+    };
+
+    /// Implementation that outputs all results to one JSON file at <output_dir>/dof_space.json
+    class CombinedJsonOutput : public OutputImpl {
+    public:
+
+      CombinedJsonOutput(fs::path output_dir);
+
+      ~CombinedJsonOutput();
+
+      using OutputImpl::write_symmetry;
+
+      void write_symmetry(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        SymGroup const &lattice_point_group,
+        SymGroup const &factor_group,
+        SymGroup const &crystal_point_group) override;
+
+      // void write_config(
+      //   Index state_index,
+      //   std::string const &identifier,
+      //   ConfigEnumInput const &config_enum_input) override;
+
+      void write_structure(
+        Index state_index,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input) override;
+
+      void write_dof_space(
+        Index state_index,
+        DoFSpace const &dof_space,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        std::optional<VectorSpaceSymReport> const &sym_report) override;
+
+    private:
+
+      jsonParser &_output_json(Index state_index);
+
+      jsonParser m_combined_json;
+
+      fs::path m_output_dir;
+
+    };
+
+
+    struct DoFSpaceAnalysisOptions {
+
+      std::vector<std::string> dofs;
+      bool sym_axes = true;
+      bool calc_wedge = false;
+      bool write_symmetry = true;
+      bool write_structure = true;
+    };
+
+    void output_dof_space(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &input_state,
+      DoFSpaceAnalysisOptions const &options,
+      OutputImpl &output);
+
+    void dof_space_analysis(
+      std::vector<std::pair<std::string, ConfigEnumInput>> const &named_inputs,
+      DoFSpaceAnalysisOptions const &options,
+      OutputImpl &output);
+  }
+
+}
+
+#endif

--- a/include/casm/enumerator/io/dof_space_analysis.hh
+++ b/include/casm/enumerator/io/dof_space_analysis.hh
@@ -11,12 +11,21 @@ namespace CASM {
   class DoFSpace;
   class SymGroup;
   struct VectorSpaceSymReport;
-  class jsonParser;
 
   namespace DoFSpaceIO {
 
     class OutputImpl {
     public:
+
+      /// Provide state_index, indentifier, and dof_key for any errors
+      struct Error {
+        Error(Index _state_index, std::string _identifier, DoFKey _dof_key, std::string _what, jsonParser _data);
+        Index state_index;
+        std::string identifier;
+        DoFKey dof_key;
+        std::string what;
+        jsonParser data;
+      };
 
       /// Write symmetry groups (lattice point group, factor_group, crystal_point_group)
       void write_symmetry(
@@ -59,6 +68,27 @@ namespace CASM {
         ConfigEnumInput const &config_enum_input,
         std::optional<VectorSpaceSymReport> const &sym_report) = 0;
 
+      /// Write dof space analysis error information
+      void write_dof_space_error(
+        make_symmetry_adapted_dof_space_error const &e,
+        Index state_index,
+        DoFSpace const &dof_space,
+        std::string const &identifier,
+        ConfigEnumInput const &config_enum_input,
+        std::optional<VectorSpaceSymReport> const &sym_report);
+
+      std::vector<Error> const &errors() const {
+        return m_errors;
+      }
+      std::vector<Error> &errors() {
+        return m_errors;
+      }
+
+      /// Write dof space analysis error information to <current_path>/dof_space_errors.json
+      void write_errors() const;
+
+    private:
+      std::vector<Error> m_errors;
     };
 
     class DirectoryOutput : public OutputImpl {

--- a/include/casm/enumerator/io/json/ConfigEnumInput_json_io.hh
+++ b/include/casm/enumerator/io/json/ConfigEnumInput_json_io.hh
@@ -12,10 +12,12 @@ namespace CASM {
 
   template<typename T> class InputParser;
   class jsonParser;
-  class Structure;
-  class Supercell;
+  template<typename T> struct jsonConstructor;
   class Configuration;
   class ConfigEnumInput;
+  class PrimClex;
+  class Structure;
+  class Supercell;
 
   namespace DB {
     template<typename T> class Database;
@@ -30,15 +32,13 @@ namespace CASM {
 
     static ConfigEnumInput from_json(
       const jsonParser &json,
-      std::shared_ptr<Structure const> const &shared_prim,
-      DB::Database<Supercell> &supercell_db);
+      std::shared_ptr<Structure const> const &shared_prim);
   };
 
   /// Read ConfigEnumInput from JSON
   void parse(
     InputParser<ConfigEnumInput> &parser,
-    std::shared_ptr<Structure const> const &shared_prim,
-    DB::Database<Supercell> &supercell_db);
+    std::shared_ptr<Structure const> const &shared_prim);
 
   /// Read std::map<std::string, ConfigEnumInput> from JSON input, allowing queries from databases
   void from_json(
@@ -53,6 +53,9 @@ namespace CASM {
   void parse(
     InputParser<xtal::ScelEnumProps> &parser,
     DB::Database<Supercell> &supercell_db);
+
+  /// A string describing the JSON format for parsing named ConfigEnumInput
+  std::string parse_ConfigEnumInput_desc();
 
   /// Parse JSON to construct initial states for enumeration (as std::map<std::string, ConfigEnumInput>)
   void parse(

--- a/include/casm/enumerator/io/json/DoFSpace.hh
+++ b/include/casm/enumerator/io/json/DoFSpace.hh
@@ -4,14 +4,39 @@
 #include <string>
 #include "casm/global/definitions.hh"
 #include "casm/global/eigen.hh"
-
+#include "casm/symmetry/SymRepTools.hh"
 
 namespace CASM {
 
-  struct DoFSpace;
+  class DoFSpace;
+  struct VectorSpaceSymReport;
   template<typename T> class InputParser;
+  template<typename T> struct jsonConstructor;
+  template<typename T> struct jsonMake;
 
-  jsonParser &to_json(DoFSpace const &dofspace, jsonParser &json, std::string name);
+  // jsonParser &to_json(DoFSpace const &dofspace, jsonParser &json);
+
+  void from_json(DoFSpace &dofspace,
+                 jsonParser const &json,
+                 std::shared_ptr<Structure const> const &shared_prim);
+
+  jsonParser &to_json(DoFSpace const &dofspace,
+                      jsonParser &json,
+                      std::optional<std::string> const &identifier = std::nullopt,
+                      std::optional<ConfigEnumInput> const &input_state = std::nullopt,
+                      std::optional<VectorSpaceSymReport> const &sym_report = std::nullopt);
+
+  template <>
+  struct jsonConstructor<DoFSpace> {
+    static DoFSpace from_json(jsonParser const &json, std::shared_ptr<Structure const> const &shared_prim);
+  };
+
+  template <>
+  struct jsonMake<DoFSpace> {
+    static std::unique_ptr<DoFSpace> make_from_json(jsonParser const &json,
+                                                    std::shared_ptr<Structure const> const &shared_prim);
+  };
+
 
   /// Data structure used for continuous DoF enumeration IO
   struct AxesCounterParams {

--- a/src/casm/app/DirectoryStructure.cc
+++ b/src/casm/app/DirectoryStructure.cc
@@ -328,9 +328,14 @@ namespace CASM {
     return configuration_dir(configname) / "POS";
   }
 
-  /// \brief Return path to config.json file
+  /// \brief Return path to standard config.json file location
   fs::path DirectoryStructure::config_json(std::string configname) const {
     return configuration_dir(configname) / "config.json";
+  }
+
+  /// \brief Return path to standard structure.json file location
+  fs::path DirectoryStructure::structure_json(std::string configname) const {
+    return configuration_dir(configname) / "structure.json";
   }
 
   /// \brief Return calculation settings directory path, for global settings

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -400,8 +400,10 @@ namespace CASM {
     parser.optional_else(output_dir, "output_dir", fs::current_path());
     report_and_throw_if_invalid(parser, log, error_if_invalid);
 
+    log << std::endl;
+
     if(print_dof_space_and_quit_option) {
-      log.begin<Log::debug>("Print DoF Space and Quit Option");
+      log.begin("Print DoF Space and Quit Option");
       log << "For large spaces this may be slow..." << std::endl;
       using namespace DoFSpaceIO;
       SequentialDirectoryOutput dof_space_output {output_dir};

--- a/src/casm/app/enum/methods/ConfigEnumStrainInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumStrainInterface.cc
@@ -321,8 +321,10 @@ namespace CASM {
     parser.optional_else(output_dir, "output_dir", fs::current_path());
     report_and_throw_if_invalid(parser, log, error_if_invalid);
 
+    log << std::endl;
+
     if(print_dof_space_and_quit_option) {
-      log.begin<Log::debug>("Print DoF Space and Quit Option");
+      log.begin("Print DoF Space and Quit Option");
       using namespace DoFSpaceIO;
       SequentialDirectoryOutput dof_space_output {output_dir};
       DoFSpaceAnalysisOptions options;

--- a/src/casm/app/enum/standard_ConfigEnumInput_help.cc
+++ b/src/casm/app/enum/standard_ConfigEnumInput_help.cc
@@ -1,134 +1,36 @@
 #include "casm/app/enum/standard_ConfigEnumInput_help.hh"
+#include "casm/enumerator/io/json/ConfigEnumInput_json_io.hh"
 
 namespace CASM {
 
   // At some point the help text may go in text files, but for now...
 
   std::string standard_ConfigEnumInput_help() {
-    return
-      "  scelnames: Array of strings (optional, override with --scelnames) \n"
-      "    Names of supercells used as initial state of occupation enumeration. All\n"
-      "    sites not being enumerated will be set to the first listed occupant, and all\n"
-      "    other DoFs will be set to zero.\n"
-      "    Ex: \"scelnames\" : [\"SCEL1_1_1_1_0_0_0\",\"SCEL2_2_1_1_0_0_0\"]\n\n"
+    return parse_ConfigEnumInput_desc() +
+           "  filter: string (optional, default=None, override with --filter)\n"
+           "    A query command to use to filter which Configurations are kept.          \n\n"
 
-      "  supercell_selection: string (optional) \n"
-      "    Name of a selection of supercells to use as initial states for enumeration.\n\n"
+           "  dry_run: bool (optional, default=false, override with --dry-run)\n"
+           "    Perform dry run.\n\n"
 
-      "  supercells: object, ScelEnum JSON settings (optional, override with --min, --max)\n"
-      "    Indicate supercells to use as initial states of enumeration in terms of size\n"
-      "    and unit cell via a JSON object conforming to the format of 'ScelEnum' JSON\n"
-      "    settings \"min\", \"max\", \"dirs\", and \"unit_cell\". See 'ScelEnum' \n"
-      "    description for more details.\n\n"
+           "  primitive_only: bool (optional, default=true)\n"
+           "    If true, only the primitive form of a configuration is saved in the      \n"
+           "    configuration list. Otherwise, both primitive and non-primitive          \n"
+           "    configurations are saved. \n\n"
 
-      "  confignames: Array of strings (optional, override with --confignames) \n"
-      "    Names of configurations to be used as initial states for enumeration. All \n"
-      "    specified sublattices or sites will be enumerated on and all other DoFs will\n"
-      "    maintain the values of the initial state.\n"
-      "    Ex: \"confignames\" : [\"SCEL1_1_1_1_0_0_0/1\",\"SCEL2_2_1_1_0_0_0/3\"]\n\n"
+           "  output_configurations: bool (optional, default=false)\n"
+           "    If true, write formatted data for each enumerated configuration. Formatting options are \n"
+           "    given by `output_configurations_options`. \n\n"
 
-      "  config_selection: string (optional) \n"
-      "    Name of a selection of configurations to use as initial states for enumeration.\n\n"
+           "  output_configurations_options: object (optional) \n"
+           "    Set output options for when `output_configurations==true`. \n\n"
 
-      "  sublats: array of integers (optional, default none) \n"
-      "    Restricts enumeration to specified sublattices. Each sublattice index corresponds\n"
-      "    to a basis site in prim.json, indexed from 0.\n"
-      "    Ex: \"sublats\" : [0,2]\n\n"
-
-      "  sites: array of 4-entry integer arrays (optional, default none) \n"
-      "    Restricts enumeration to specified sites. Sites are specified in [b,i,j,k] convention,\n"
-      "    where 'b' is sublattice index and [i,j,k] specifies linear combinations of primitive-\n"
-      "    cell lattice vectors.\n"
-      "    Ex: \"sites\" : [[0,0,0,0],\n"
-      "                   [2,0,0,0]]\n\n"
-
-      "  cluster_specs: object (optional) \n"
-      "    JSON object specifying orbits of clusters to generate. Each orbit prototype is used \n"
-      "    to select sites to enumerate on each selected supercell or configuration. If there are \n"
-      "    4 supercells or configurations selected, and there are 10 orbits generated, then there \n"
-      "    will be 4*10=40 initial states generated. The \"cluster_specs\" option cannot be used \n"
-      "    with the \"sublats\" or \"sites\" options. Expect format is: \n\n"
-
-      "    method: string (required) \n"
-      "      Specify which cluster orbit generating method will be used. Supported: \n"
-      "      - \"periodic_max_length\": Clusters differing by a lattice translation are considered \n"
-      "        equivalent. Cluster generation is truncated by specifying the maximum distance \n"
-      "        between sites in a cluster for 2-point, 3-point, etc. clusters. The point clusters \n"
-      "        comprising the asymmetric unit of the prim structure are always included. For \n"
-      "        enumeration input purposes, after the cluster orbits are generated using the prim \n"
-      "        factor group symmetry, the orbits are broken into sub-orbits reflecting the \n"
-      "        configuration factor group symmetry of the initial enumeration state. Any orbits that \n"
-      "        are duplicated under periodic boundary conditions are removed. \n\n"
-
-      "    params: object (required) \n"
-      "      Specifies parameters for the method selected by `method`. Options depend on the \n"
-      "      `method` chosen: \n\n"
-
-      "      For method==\"periodic_max_length\": \n"
-      "        orbit_branch_specs: object (optional)\n"
-      "          Cluster generation is truncated by specifying the maximum distance\n"
-      "          between sites in a cluster for each orbit branch (i.e. 2-point, 3-point, etc.\n"
-      "          clusters). The 1-point clusters comprising the asymmetric unit of the prim\n"
-      "          structure are always included. \n\n"
-
-      "            Example: \n"
-      "              \"orbit_branch_specs\": {\n"
-      "                \"2\": { \"max_length\": 10.0 },\n"
-      "                \"3\": { \"max_length\": 8.0 },\n"
-      "                       ...\n"
-      "              }\n\n"
-
-      "        orbit_specs: array (optional) \n"
-      "          An array of clusters which are used to generate and include orbits of clusters \n"
-      "          whether or not they meet the `max_length` truncation criteria. See the \n"
-      "          cluster input format below. Use the \"include_subclusters\" option to force \n"
-      "          generation of orbits for all subclusters of the specified cluster. \n"
-
-      "            Example cluster, with \"Direct\" coordinates: \n"
-      "              { \n"
-      "                \"coordinate_mode\" : \"Direct\", \n"
-      "                \"sites\" : [ \n"
-      "                  [ 0.000000000000, 0.000000000000, 0.000000000000 ], \n"
-      "                  [ 1.000000000000, 0.000000000000, 0.000000000000 ], \n"
-      "                  [ 2.000000000000, 0.000000000000, 0.000000000000 ], \n"
-      "                  [ 3.000000000000, 0.000000000000, 0.000000000000 ]], \n"
-      "                \"include_subclusters\" : true \n"
-      "              } \n\n"
-
-      "            Example cluster, with \"Integral\" coordinates: \n"
-      "              { \n"
-      "                \"coordinate_mode\" : \"Integral\", \n"
-      "                \"sites\" : [ \n"
-      "                  [ 0, 0, 0, 0 ], \n"
-      "                  [ 0, 1, 0, 0 ], \n"
-      "                  [ 1, 0, 0, 0 ]], \n"
-      "                \"include_subclusters\" : true \n"
-      "              } \n\n"
-
-      "  filter: string (optional, default=None, override with --filter)\n"
-      "    A query command to use to filter which Configurations are kept.          \n\n"
-
-      "  dry_run: bool (optional, default=false, override with --dry-run)\n"
-      "    Perform dry run.\n\n"
-
-      "  primitive_only: bool (optional, default=true)\n"
-      "    If true, only the primitive form of a configuration is saved in the      \n"
-      "    configuration list. Otherwise, both primitive and non-primitive          \n"
-      "    configurations are saved. \n\n"
-
-      "  output_configurations: bool (optional, default=false)\n"
-      "    If true, write formatted data for each enumerated configuration. Formatting options are \n"
-      "    given by `output_options`. \n\n"
-
-      "  output_configurations_options: object (optional) \n"
-      "    Set output options for when `output_configurations==true`. \n\n"
-
-      "      path: string (optional, default=\"enum.out\") Output file name.\n"
-      "      json: bool (optional, default=false) If true, write JSON output files. Else CSV style.\n"
-      "      json_arrays: bool (optional, default=false) If true, write data in JSON arrays. \n"
-      "      compress: bool (optional, default=false) If true, compress data using gz. If `path` \n"
-      "      does not end in '.gz' it will be appended. \n"
-      "      output_filtered_configurations: bool (optional, default=false) If true, also include \n"
-      "      output from configurations that excluded by the `filter` option.\n\n";
+           "      path: string (optional, default=\"enum.out\") Output file name.\n"
+           "      json: bool (optional, default=false) If true, write JSON output files. Else CSV style.\n"
+           "      json_arrays: bool (optional, default=false) If true, write data in JSON arrays. \n"
+           "      compress: bool (optional, default=false) If true, compress data using gz. If `path` \n"
+           "      does not end in '.gz' it will be appended. \n"
+           "      output_filtered_configurations: bool (optional, default=false) If true, also include \n"
+           "      output from configurations that excluded by the `filter` option.\n\n";
   };
 }

--- a/src/casm/app/io/file/clex_io.cc
+++ b/src/casm/app/io/file/clex_io.cc
@@ -1,0 +1,53 @@
+#ifndef CASM_app_clex_file_io
+#define CASM_app_clex_file_io
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include "casm/app/DirectoryStructure.hh"
+#include "casm/casm_io/json/jsonParser.hh"
+#include "casm/crystallography/Lattice.hh"
+#include "casm/crystallography/SimpleStructure.hh"
+#include "casm/crystallography/io/SimpleStructureIO.hh"
+#include "casm/clex/Configuration.hh"
+#include "casm/clex/SimpleStructureTools.hh"
+#include "casm/clex/Supercell.hh"
+#include "casm/clex/io/json/Configuration_json_io.hh"
+#include "casm/clex/io/stream/Configuration_stream_io.hh"
+
+namespace CASM {
+
+  /// Write supercell "LAT" file (supercell lattice vectors as column vectors) to standard location
+  void write_lat(Supercell const &supercell, DirectoryStructure const &dir) {
+    fs::create_directories(dir.configuration_dir(supercell.name()));
+    fs::ofstream outfile {dir.LAT(supercell.name())};
+    outfile << supercell.lattice().lat_column_mat() << std::endl;
+  }
+
+  /// Write configuration "POS" file (VASP POSCAR) to standard location
+  void write_pos(Configuration const &configuration, DirectoryStructure const &dir) {
+    fs::create_directories(dir.configuration_dir(configuration.name()));
+    fs::ofstream outfile {dir.POS(configuration.name())};
+    print_poscar(configuration, outfile);
+  }
+
+  /// Write configuration "structure.json" file (structure that results from appling DoF) to standard location
+  void write_structure_json(Configuration const &configuration, DirectoryStructure const &dir) {
+    fs::create_directories(dir.configuration_dir(configuration.name()));
+    fs::ofstream outfile {dir.structure_json(configuration.name())};
+    jsonParser json;
+    to_json(make_simple_structure(configuration), json);
+    json.print(outfile);
+  }
+
+  /// Write configuration "config.json" file (DoF values in standard basis) to standard location
+  void write_config_json(Configuration const &configuration, DirectoryStructure const &dir) {
+    fs::create_directories(dir.configuration_dir(configuration.name()));
+    fs::ofstream outfile {dir.config_json(configuration.name())};
+    jsonParser json;
+    to_json(configuration, json);
+    json.print(outfile);
+  }
+
+}
+
+#endif

--- a/src/casm/app/query.cc
+++ b/src/casm/app/query.cc
@@ -2,15 +2,16 @@
 #include "casm/app/DBInterface.hh"
 #include "casm/app/ProjectSettings.hh"
 #include "casm/app/QueryHandler_impl.hh"
+#include "casm/app/io/file/clex_io.hh"
 #include "casm/app/query/QueryIO_impl.hh"
 #include "casm/casm_io/FormatFlag.hh"
 #include "casm/casm_io/Log.hh"
 #include "casm/clex/ConfigEnumByPermutation.hh"
 #include "casm/clex/PrimClex.hh"
+#include "casm/clex/io/json/ConfigDoF_json_io.hh"
 #include "casm/database/DatabaseTypes_impl.hh"
 #include "casm/database/Selection.hh"
 
-#include "casm/clex/io/json/ConfigDoF_json_io.hh"
 
 namespace CASM {
 
@@ -54,6 +55,15 @@ namespace CASM {
 
   }
 
+
+  namespace query_impl {
+
+    /// For 'write_pos' with Supercell use 'write_lat'
+    void write_pos(Supercell const &supercell, DirectoryStructure const &dir) {
+      write_lat(supercell, dir);
+    }
+
+  }
 
   // -- QueryCommandImplBase --------------------------------------------
 
@@ -299,8 +309,9 @@ namespace CASM {
 
   template<typename DataObject>
   int QueryCommandImpl<DataObject>::_write_pos() const {
+    using namespace query_impl;
     for(const auto &obj : _sel().selected()) {
-      write_pos(obj);
+      write_pos(obj, m_cmd.primclex().dir());
     }
     return 0;
   }

--- a/src/casm/app/run.cc
+++ b/src/casm/app/run.cc
@@ -3,6 +3,7 @@
 
 #include "casm/app/casm_functions.hh"
 #include "casm/app/DirectoryStructure.hh"
+#include "casm/app/io/file/clex_io.hh"
 #include "casm/clex/Configuration_impl.hh"
 #include "casm/database/Selection.hh"
 #include "casm/completer/Handlers.hh"
@@ -108,8 +109,8 @@ namespace CASM {
 
       DB::Selection<Configuration> config_select(primclex.db<Configuration>(), selection);
       for(const auto &config : config_select.selected()) {
-        write_pos(config);
-        write_config_json(config);
+        write_pos(config, primclex.dir());
+        write_config_json(config, primclex.dir());
 
         Popen process;
 
@@ -135,5 +136,3 @@ namespace CASM {
   };
 
 }
-
-

--- a/src/casm/app/sym/dof_space_analysis.cc
+++ b/src/casm/app/sym/dof_space_analysis.cc
@@ -1,122 +1,75 @@
-#include <map>
-#include "casm/app/APICommand.hh"
-#include "casm/app/AppIO.hh"
-#include "casm/app/DirectoryStructure.hh"
 #include "casm/app/io/json_io.hh"
 #include "casm/app/sym/dof_space_analysis.hh"
-#include "casm/casm_io/Log.hh"
 #include "casm/casm_io/container/json_io.hh"
 #include "casm/casm_io/json/InputParser_impl.hh"
 #include "casm/clex/PrimClex.hh"
 #include "casm/crystallography/Structure.hh"
 #include "casm/enumerator/ConfigEnumInput.hh"
 #include "casm/enumerator/DoFSpace_impl.hh"
+#include "casm/enumerator/io/dof_space_analysis.hh"
 #include "casm/enumerator/io/json/ConfigEnumInput_json_io.hh"
-#include "casm/enumerator/io/json/DoFSpace.hh"
-#include "casm/symmetry/SymRepTools.hh"
-#include "casm/symmetry/io/json/SymRepTools.hh"
-
-namespace dof_space_analysis_impl {
-
-  using namespace CASM;
-
-  jsonParser combine_dof_space_analysis_json_options(jsonParser const &json_options,
-                                                     jsonParser const &cli_options_as_json) {
-
-    std::map<std::string, std::string> cli_to_combined_keys {
-      {"scelnames", "scelnames"},         // --scelnames
-      {"confignames", "confignames"},     // --confignames
-      {"selection", "config_selection"},  // --selection
-      {"dofs", "dofs"},                   // --dofs
-      {"calc_wedge", "calc_wedge"}        // --calc-wedge
-    };
-
-    jsonParser json_combined {json_options};
-    return combine_json_options(cli_to_combined_keys,
-                                cli_options_as_json,
-                                json_combined);
-  }
-
-  template<typename PermuteIteratorIt>
-  void write_config_symmetry_files(ConfigEnumInput const &config,
-                                   PermuteIteratorIt group_begin,
-                                   PermuteIteratorIt group_end,
-                                   fs::path sym_dir) {
-
-    Lattice config_lattice = config.configuration().ideal_lattice();
-
-    SymGroup config_factor_group = make_sym_group(group_begin, group_end, config_lattice);
-
-    // Write lattice point group
-    {
-      SymGroup config_lattice_pg(SymGroup::lattice_point_group(config_lattice));
-      jsonParser json;
-      write_symgroup(config_lattice_pg, json);
-      fs::ofstream outfile {sym_dir / "lattice_point_group.json"};
-      json.print(outfile);
-    }
-
-    // Write factor group
-    {
-      jsonParser json;
-      write_symgroup(config_factor_group, json);
-      fs::ofstream outfile {sym_dir / "factor_group.json"};
-      json.print(outfile);
-    }
-
-    // Write crystal point group
-    {
-      SymGroup config_point_group = make_point_group(group_begin, group_end, config_lattice);
-      jsonParser json;
-      write_symgroup(config_point_group, json);
-      fs::ofstream outfile {sym_dir / "crystal_point_group.json"};
-      json.print(outfile);
-    }
-  }
-
-  /// For now, only support "confignames" and "config_selection" for reading ConfigEnumInput
-  ///
-  /// Later, could support other ConfigEnumInput JSON options (supercells, selecting sites, clusters,
-  /// etc.), but need to determine how to write / print the data
-  void require_database_configurations(ParentInputParser &parser) {
-    std::set<std::string> do_not_allow {
-      "scelnames",
-      "supercell_selection",
-      "supercells",
-      "sublats",
-      "sites",
-      "cluster_specs"};
-
-    for(auto key : do_not_allow) {
-      if(parser.self.contains(key)) {
-        std::stringstream msg;
-        msg << "Error in dof_space_analysis: \"" << key << "\" is not an allowed option.";
-        parser.error.insert(msg.str());
-      }
-    }
-  }
-
-  /// Parser "dofs" value for dof space analysis
-  ///
-  /// dofs: array of string (optional, default=all_dof_types)
-  ///     Entries must exist in "all_dof_types" else an error is inserted.
-  ///
-  void parse_dofs(ParentInputParser &parser,
-                  std::vector<DoFKey> &dofs,
-                  std::vector<DoFKey> const &all_dof_types) {
-    parser.optional_else(dofs, "dofs", all_dof_types);
-    for(DoFKey const &dof : dofs) {
-      if(std::find(all_dof_types.begin(), all_dof_types.end(), dof) == all_dof_types.end()) {
-        std::stringstream msg;
-        msg << "Error parsing \"dofs\": \"" << dof << "\" is invalid.";
-        parser.error.insert(msg.str());
-      }
-    }
-  }
-
-}
 
 namespace CASM {
+  namespace DoFSpaceIO {
+
+    jsonParser combine_dof_space_analysis_json_options(jsonParser const &json_options,
+                                                       jsonParser const &cli_options_as_json) {
+
+      std::map<std::string, std::string> cli_to_combined_keys {
+        {"scelnames", "scelnames"},         // --scelnames
+        {"confignames", "confignames"},     // --confignames
+        {"selection", "config_selection"},  // --selection
+        {"dofs", "dofs"},                   // --dofs
+        {"calc_wedge", "calc_wedge"}        // --calc-wedge
+      };
+
+      jsonParser json_combined {json_options};
+      return combine_json_options(cli_to_combined_keys,
+                                  cli_options_as_json,
+                                  json_combined);
+    }
+
+    /// For now, only support "confignames" and "config_selection" for reading ConfigEnumInput
+    ///
+    /// Later, could support other ConfigEnumInput JSON options (supercells, selecting sites, clusters,
+    /// etc.), but need to determine how to write / print the data
+    void require_database_configurations(ParentInputParser &parser) {
+      std::set<std::string> do_not_allow {
+        "scelnames",
+        "supercell_selection",
+        "supercells",
+        "sublats",
+        "sites",
+        "cluster_specs"};
+
+      for(auto key : do_not_allow) {
+        if(parser.self.contains(key)) {
+          std::stringstream msg;
+          msg << "Error in dof_space_analysis: \"" << key << "\" is not an allowed option.";
+          parser.error.insert(msg.str());
+        }
+      }
+    }
+
+    /// Parser "dofs" value for dof space analysis
+    ///
+    /// dofs: array of string (optional, default=all_dof_types)
+    ///     Entries must exist in "all_dof_types" else an error is inserted.
+    ///
+    void parse_dofs(ParentInputParser &parser,
+                    std::vector<DoFKey> &dofs,
+                    std::vector<DoFKey> const &all_dof_types) {
+      parser.optional_else(dofs, "dofs", all_dof_types);
+      for(DoFKey const &dof : dofs) {
+        if(std::find(all_dof_types.begin(), all_dof_types.end(), dof) == all_dof_types.end()) {
+          std::stringstream msg;
+          msg << "Error parsing \"dofs\": \"" << dof << "\" is invalid.";
+          parser.error.insert(msg.str());
+        }
+      }
+    }
+
+  } // end namespace DoFSpaceIO
 
   /// Describe DoF space analysis
   std::string dof_space_analysis_desc() {
@@ -145,18 +98,44 @@ namespace CASM {
       "      for each input configuration. The default includes all DoF types in the    \n"
       "      prim.                                                                      \n\n"
 
-      "    confignames: Array of strings (optional, override with --confignames)        \n"
-      "      Names of configurations to be used as initial states for enumeration. All  \n"
-      "      specified sublattices or sites will be enumerated on and all other DoFs    \n"
-      "      will maintain the values of the initial state.                             \n"
-      "      Ex: \"confignames\" : [\"SCEL1_1_1_1_0_0_0/1\",\"SCEL2_2_1_1_0_0_0/3\"]    \n\n"
-
-      "    config_selection: string (optional, override with --selection)               \n"
-      "      Name of a selection of configurations to perform analysis on.              \n\n"
-
       "    calc_wedge: bool (optional, default=false, override with --calc-wedge)       \n"
       "      Perform calculation of irreducible wedge (may significantly slow down      \n"
-      "      analysis).                                                                 \n\n";
+      "      analysis).                                                                 \n\n"
+
+      "    write_symmetry: bool (optional, default=true)                                \n"
+      "      If true (default), write the lattice point group, factor group (operations \n"
+      "      leave the configuration and selected sites invariant), and crystal point   \n"
+      "      group (factor group operations excluding translations) of the initial state\n"
+      "      for analysis.                                                              \n\n"
+
+      "    write_structure: bool (optional, default=true)                               \n"
+      "      If true (default), write a \"structure.json\" file containing the structure\n"
+      "      generated from the configuration DoF.                                      \n\n"
+
+      "    output_type: string (optional, default=\"symmetry_directory\")               \n"
+      "      Selects how output files are written. Options are:                         \n\n"
+
+      "      \"symmetry_directory\": (default)                                          \n"
+      "        If selected, only accepts \"confignames\" and \"config_selection\"       \n"
+      "        to specify the initial state for analysis and the results are stored in  \n"
+      "        dedicated folders in the CASM project symmetry directory:                \n"
+      "            \"<project_path>/symmetry/analysis/<configname>\".                   \n\n"
+
+      "      \"sequential\":                                                            \n"
+      "        If selected, accept any input for specifying the initial state for       \n"
+      "        analysis, including \"scelnames\", \"supercell_selection\", \"supercells\"\n"
+      "        \"sublats\", \"sites\", and \"cluster_specs\", and the results are stored\n"
+      "        in indexed folders \"<output_dir>/dof_space_analysis/state.<index>\".  \n\n"
+
+      "      \"combined_json\":                                                         \n"
+      "        If selected, accept any input for specifying the initial state for       \n"
+      "        analysis, including \"scelnames\", \"supercell_selection\", \"supercells\",\n"
+      "        \"sublats\", \"sites\", and \"cluster_specs\", and the results are stored\n"
+      "        in a single JSON file \"<output_dir>/dof_space_analysis.json\" instead \n"
+      "        of being written separately.                                             \n"
+
+      "    output_dir: string (optional, default=current path)                          \n"
+      "      Selects where output files are written.                                    \n\n";
 
     return description;
   }
@@ -176,10 +155,9 @@ namespace CASM {
                           jsonParser const &json_options,
                           jsonParser const &cli_options_as_json) {
 
-    using namespace dof_space_analysis_impl;
+    using namespace DoFSpaceIO;
 
     Log &log = CASM::log();
-    DirectoryStructure const &dir = primclex.dir();
 
     log.subsection().begin<Log::debug>("dof_space_analysis");
     log.indent() << "json_options:\n" << json_options << std::endl << std::endl;
@@ -197,8 +175,32 @@ namespace CASM {
     ParentInputParser parser {json_combined};
     std::runtime_error error_if_invalid {"Error reading `casm sym --dof-space-analysis` input"};
 
-    // For now, only allow input that is configurations already existing in the database
-    require_database_configurations(parser);
+
+    // 1) parse options
+
+    DoFSpaceAnalysisOptions options;
+
+    // parse "dofs" (optional, default = all dof types)
+    parse_dofs(parser, options.dofs, all_dof_types(primclex.prim().structure()));
+
+    // parse "calc_wedge" (optional, default = false)
+    parser.optional_else(options.calc_wedge, "calc_wedge", false);
+
+    // parse "write_symmetry" (optional, default = true)
+    parser.optional_else(options.write_symmetry, "write_symmetry", true);
+
+    // parse "write_structure" (optional, default = true)
+    parser.optional_else(options.write_structure, "write_structure", true);
+
+    // parse "output_type"= "symmetry_directory" (default), "sequential", or "combined_json"
+    std::string output_type;
+    parser.optional_else(output_type, "output_type", std::string("symmetry_directory"));
+
+    // parse "output_dir" (optional, default = current_path)
+    fs::path output_dir;
+    parser.optional_else(output_dir, "output_dir", fs::current_path());
+
+    // 2) parse input states
 
     typedef std::vector<std::pair<std::string, ConfigEnumInput>> NamedConfigEnumInput;
     auto input_parser_ptr = parser.parse_as<NamedConfigEnumInput>(
@@ -206,65 +208,35 @@ namespace CASM {
                               &primclex,
                               primclex.db<Supercell>(),
                               primclex.db<Configuration>());
-
-    // parse "dofs" (optional, default = all dof types)
-    std::vector<DoFKey> dofs;
-    parse_dofs(parser, dofs, all_dof_types(primclex.prim().structure()));
-
-    // parse "calc_wedge" (optional, default = false)
-    bool calc_wedge;
-    parser.optional_else(calc_wedge, "calc_wedge", false);
-
     report_and_throw_if_invalid(parser, log, error_if_invalid);
-
-    // For each enumeration envrionment, for each DoF type specified, perform analysis and write files.
     auto const &named_inputs = *input_parser_ptr->value;
-    for(auto const &named_input : named_inputs) {
 
-      std::string name = named_input.first;
-      log.begin(name);
-      log.increase_indent();
 
-      ConfigEnumInput const &config_enum_input = named_input.second;
-      Configuration const &configuration = config_enum_input.configuration();
-      std::vector<PermuteIterator> group = make_invariant_subgroup(configuration);
+    // 3) Construct output method implementation and run dof space analysis
 
-      // These should not occur for now. They should be prevented by require_database_configurations.
-      // TODO: add support for other dof space analyses
-      if(configuration.id() == "none") {
-        throw std::runtime_error("Error in dof_space_analysis: configuration does not exist in database.");
-      }
-      if(name != configuration.name()) {
-        throw std::runtime_error("Error in dof_space_analysis: name error.");
-      }
-      if(config_enum_input.sites().size() != configuration.size()) {
-        throw std::runtime_error("Error in dof_space_analysis: incomplete site selection error.");
-      }
+    if(output_type == "combined_json") {
+      // write all output to one large JSON file: <output_dir>/dof_space_analysis.json
+      CombinedJsonOutput output {output_dir};
+      dof_space_analysis(named_inputs, options, output);
+    }
+    else if(output_type == "sequential") {
+      // write output sequentially indexed directories: <output_dir>/dof_space_analysis/state.<index>/
+      SequentialDirectoryOutput output {output_dir};
+      dof_space_analysis(named_inputs, options, output);
+    }
+    else if(output_type == "symmetry_directory") {
+      require_database_configurations(parser);
+      report_and_throw_if_invalid(parser, log, error_if_invalid);
 
-      fs::path sym_dir = dir.symmetry_dir(configuration.name());
-      fs::create_directories(sym_dir);
-
-      // for configuration, write lattice_point_group.json, factor_group.json, crystal_point_group.json
-      write_config_symmetry_files(config_enum_input, group.begin(), group.end(), sym_dir);
-
-      // write "dof_analysis_<dof>.json" for each specified DoF type
-      for(DoFKey const &dof : dofs) {
-        log << "Working on: " << name << " " << dof << std::endl;
-        DoFSpace dof_space {config_enum_input, dof};
-        auto report = vector_space_sym_report(dof_space, group.begin(), group.end(), calc_wedge);
-
-        jsonParser json;
-        to_json(report, json);
-        to_json(dof_space, json, name);
-
-        std::string filename = "dof_analysis_" + dof + ".json";
-        json.write(sym_dir / filename);
-        log << "Writing: " << (sym_dir / filename) << std::endl << std::endl;
-
-      }
-
-      log.decrease_indent();
-      log << std::endl;
+      // write output to CASM project symmetry directory: <project_path>/symmetry/analysis/<configname>/
+      SymmetryDirectoryOutput output {primclex.dir()};
+      dof_space_analysis(named_inputs, options, output);
+    }
+    else {
+      std::string msg = "Error: 'output_type' must be one of \"symmetry_directory\" (default), "
+                        "\"sequential\", or \"combined_json\"";
+      parser.insert_error("output_type", msg);
+      report_and_throw_if_invalid(parser, log, error_if_invalid);
     }
   }
 }

--- a/src/casm/clex/ConfigDoF.cc
+++ b/src/casm/clex/ConfigDoF.cc
@@ -122,48 +122,16 @@ namespace CASM {
 
   //*******************************************************************************
 
+  /// This function is deprecated in favor of the standalone `to_json`
   jsonParser &ConfigDoF::to_json(jsonParser &json) const {
-    json = jsonParser::object();
-    if(occupation().size())
-      json["occ"] = m_occupation;
-    if(!m_local_dofs.empty()) {
-      json["local_dofs"] = m_local_dofs;
-    }
-    if(!m_global_dofs.empty()) {
-      json["global_dofs"] = m_global_dofs;
-    }
-
-    return json;
+    return CASM::to_json(*this, json);
   }
 
   //*******************************************************************************
-  void ConfigDoF::from_json(const jsonParser &json) { //, Index NB) {
-    if(json.contains("occupation")) {
-      //For Backwards compatibility
-      CASM::from_json(m_occupation, json["occupation"]);
-    }
-    else if(json.contains("occ")) {
-      CASM::from_json(m_occupation, json["occ"]);
-    }
-    else {
-      throw std::runtime_error("JSON serialization of ConfigDoF must contain field \"occ\"\n");
-    }
 
-
-    if(json.contains("local_dofs")) {
-      auto end_it = json["local_dofs"].end();
-      for(auto it = json["local_dofs"].begin(); it != end_it; ++it)
-        CASM::from_json(m_local_dofs[it.name()], *it);
-      //.emplace(it.name(), LocalValueType(DoF::traits(it.name()), NB, m_occupation.size() / NB, (*it)["values"].get<Eigen::MatrixXd>()));
-    }
-
-    if(json.contains("global_dofs")) {
-      auto end_it = json["global_dofs"].end();
-      for(auto it = json["global_dofs"].begin(); it != end_it; ++it)
-        CASM::from_json(m_global_dofs[it.name()], *it);
-      //m_global_dofs.emplace(it.name(), GlobalValueType(DoF::traits(it.name()), NB, m_occupation.size() / NB, (*it)["values"].get<Eigen::VectorXd>()));
-    }
-
+  /// This function is deprecated in favor of the standalone `from_json`
+  void ConfigDoF::from_json(const jsonParser &json) {
+    CASM::from_json(*this, json);
   }
 
   //*******************************************************************************

--- a/src/casm/clex/ConfigDoFTools.cc
+++ b/src/casm/clex/ConfigDoFTools.cc
@@ -1,0 +1,16 @@
+#include "casm/clex/ConfigDoF.hh"
+#include "casm/crystallography/Structure.hh"
+
+namespace CASM {
+
+  /// Construct zero-valued ConfigDoF
+  ConfigDoF make_configdof(Structure const &prim, Index volume) {
+    return ConfigDoF(prim.basis().size(),
+                     volume,
+                     global_dof_info(prim),
+                     local_dof_info(prim),
+                     prim.occupant_symrep_IDs(),
+                     prim.lattice().tol());
+  }
+
+}

--- a/src/casm/clex/ConfigDoFValues.cc
+++ b/src/casm/clex/ConfigDoFValues.cc
@@ -5,7 +5,7 @@ namespace CASM {
   void LocalContinuousConfigDoFValues::from_standard_values(Eigen::Ref<const Eigen::MatrixXd> const &_standard_values) {
     resize_vol(_standard_values.cols() / n_sublat());
     for(Index b = 0; b < n_sublat(); ++b)
-      sublat(b).topRows(info()[b].dim()) = info()[b].inv_basis() * _standard_values.block(0, b * n_vol(), dim(), n_vol());
+      sublat(b).topRows(info()[b].dim()) = info()[b].inv_basis() * _standard_values.block(0, b * n_vol(), m_vals.rows(), n_vol());
   }
 
   void GlobalContinuousConfigDoFValues::from_standard_values(Eigen::Ref<const Eigen::MatrixXd> const &_standard_values) {

--- a/src/casm/clex/ConfigIO.cc
+++ b/src/casm/clex/ConfigIO.cc
@@ -1,7 +1,9 @@
 #include "casm/clex/ConfigIO.hh"
 
 #include <functional>
+#include "casm/crystallography/SimpleStructure.hh"
 #include "casm/crystallography/Structure.hh"
+#include "casm/crystallography/io/SimpleStructureIO.hh"
 #include "casm/clex/PrimClex.hh"
 #include "casm/clex/Norm.hh"
 #include "casm/clex/Calculable.hh"
@@ -10,6 +12,11 @@
 #include "casm/clex/ConfigIOStrucScore.hh"
 #include "casm/clex/ConfigIOStrain.hh"
 #include "casm/clex/ConfigMapping.hh"
+#include "casm/clex/MappedProperties.hh"
+#include "casm/clex/SimpleStructureTools.hh"
+#include "casm/clex/io/json/ConfigDoF_json_io.hh"
+#include "casm/casm_io/container/json_io.hh"
+#include "casm/casm_io/json/jsonParser.hh"
 #include "casm/casm_io/Log.hh"
 #include "casm/casm_io/dataformatter/DataFormatter_impl.hh"
 #include "casm/casm_io/dataformatter/DataFormatterTools_impl.hh"
@@ -570,7 +577,44 @@ namespace CASM {
                                             has_relaxed_magmom);
     }
 
+    ConfigIO::GenericConfigFormatter<jsonParser> config() {
+      return GenericConfigFormatter<jsonParser>(
+               "config",
+               "Structure resulting from application of DoF, formatted as JSON",
+      [](Configuration const & configuration) {
+        jsonParser json = jsonParser::object();
+        to_json(make_simple_structure(configuration), json);
+        return json;
+      });
+    }
 
+    ConfigIO::GenericConfigFormatter<jsonParser> dof() {
+      return GenericConfigFormatter<jsonParser>(
+               "dof",
+               "All degrees of freedom (DoF), formatted as JSON",
+      [](Configuration const & configuration) {
+        return jsonParser {configuration.configdof()};
+      });
+    }
+
+    ConfigIO::GenericConfigFormatter<jsonParser> properties() {
+      return GenericConfigFormatter<jsonParser>(
+               "properties",
+               "All mapped properties, by calctype, formatted as JSON",
+      [](Configuration const & configuration) {
+        return jsonParser {configuration.calc_properties_map()};
+      });
+    }
+
+    ConfigIO::GenericConfigFormatter<std::string> poscar() {
+      return GenericConfigFormatter<std::string>(
+               "poscar",
+               "Structure resulting from application of DoF, formatted as VASP POSCAR",
+      [](Configuration const & configuration) {
+        return pos_string(configuration);
+      });
+
+    }
 
     /*End ConfigIO*/
   }
@@ -589,7 +633,8 @@ namespace CASM {
       scelname(),
       calc_status(),
       failure_type(),
-      point_group_name()
+      point_group_name(),
+      poscar()
     );
 
     return dict;
@@ -690,6 +735,21 @@ namespace CASM {
 
     dict.insert(
       GradCorr()
+    );
+
+    return dict;
+  }
+
+  template<>
+  DataFormatterDictionary<Configuration, BaseValueFormatter<jsonParser, Configuration>> make_json_dictionary<Configuration>() {
+
+    using namespace ConfigIO;
+    DataFormatterDictionary<Configuration, BaseValueFormatter<jsonParser, Configuration>> dict;
+
+    dict.insert(
+      config(),
+      dof(),
+      properties()
     );
 
     return dict;

--- a/src/casm/clex/ConfigIO.cc
+++ b/src/casm/clex/ConfigIO.cc
@@ -15,6 +15,7 @@
 #include "casm/clex/MappedProperties.hh"
 #include "casm/clex/SimpleStructureTools.hh"
 #include "casm/clex/io/json/ConfigDoF_json_io.hh"
+#include "casm/clex/io/stream/Configuration_stream_io.hh"
 #include "casm/casm_io/container/json_io.hh"
 #include "casm/casm_io/json/jsonParser.hh"
 #include "casm/casm_io/Log.hh"
@@ -611,7 +612,9 @@ namespace CASM {
                "poscar",
                "Structure resulting from application of DoF, formatted as VASP POSCAR",
       [](Configuration const & configuration) {
-        return pos_string(configuration);
+        std::stringstream ss;
+        print_poscar(configuration, ss);
+        return ss.str();
       });
 
     }

--- a/src/casm/clex/Configuration.cc
+++ b/src/casm/clex/Configuration.cc
@@ -30,8 +30,6 @@
 #include "casm/crystallography/SimpleStructureTools.hh"
 #include "casm/crystallography/Structure.hh"
 #include "casm/crystallography/SymTools.hh"
-#include "casm/crystallography/io/VaspIO.hh"
-#include "casm/crystallography/io/SimpleStructureIO.hh"
 #include "casm/database/ConfigDatabase.hh"
 #include "casm/database/ConfigDatabaseTools.hh"
 #include "casm/database/Named_impl.hh"
@@ -779,78 +777,6 @@ namespace CASM {
     }
     ConfigIsEquivalent f(*this, crystallography_tol());
     return f(B);
-  }
-
-  Configuration jsonConstructor<Configuration>::from_json(
-    const jsonParser &json,
-    const PrimClex &primclex,
-    const std::string &configname) {
-
-    return Configuration(primclex, configname, json);
-  }
-
-  Configuration jsonConstructor<Configuration>::from_json(
-    const jsonParser &json,
-    const Supercell &scel,
-    const std::string &id) {
-
-    return Configuration(scel, id, json);
-  }
-
-  //*********************************************************************************
-
-  std::string pos_string(Configuration const  &_config) {
-    std::stringstream ss;
-    VaspIO::PrintPOSCAR p(make_simple_structure(_config), _config.name());
-    p.sort();
-    p.print(ss);
-    return ss.str();
-  }
-
-  //*********************************************************************************
-
-  void write_pos(Configuration const &_config) {
-
-    try {
-      fs::create_directories(_config.primclex().dir().configuration_dir(_config.name()));
-    }
-    catch(const fs::filesystem_error &ex) {
-      std::cerr << "Error in Configuration::write_pos()." << std::endl;
-      std::cerr << ex.what() << std::endl;
-    }
-
-    fs::ofstream(_config.primclex().dir().POS(_config.name()))
-        << pos_string(_config);
-    return;
-  }
-
-
-  //*********************************************************************************
-
-  std::string config_json_string(Configuration const  &_config) {
-    std::stringstream ss;
-
-    jsonParser tjson;
-    to_json(make_simple_structure(_config), tjson);
-    tjson.print(ss);
-    return ss.str();
-  }
-
-  //*********************************************************************************
-
-  void write_config_json(Configuration const &_config) {
-
-    try {
-      fs::create_directories(_config.primclex().dir().configuration_dir(_config.name()));
-    }
-    catch(const fs::filesystem_error &ex) {
-      std::cerr << "Error in Configuration::write_pos()." << std::endl;
-      std::cerr << ex.what() << std::endl;
-    }
-
-    fs::ofstream(_config.primclex().dir().config_json(_config.name()))
-        << config_json_string(_config);
-    return;
   }
 
 

--- a/src/casm/clex/SimpleStructureTools.cc
+++ b/src/casm/clex/SimpleStructureTools.cc
@@ -1,3 +1,4 @@
+#include <string>
 #include "casm/clex/SimpleStructureTools.hh"
 #include "casm/crystallography/SimpleStructureTools.hh"
 #include "casm/crystallography/SimpleStructure.hh"
@@ -8,6 +9,17 @@
 #include "casm/basis_set/DoFTraits.hh"
 
 namespace CASM {
+
+  namespace clex_SimpleStructureTools_impl {
+
+    /// \brief Imposes DoF values from ConfigDoF _config onto *this, using using any necessary
+    ///        information contained in _reference
+    void _apply_dofs(xtal::SimpleStructure &_sstruc,
+                     ConfigDoF const &_config,
+                     xtal::BasicStructure const &_reference,
+                     std::vector<DoFKey> which_dofs);
+
+  }
 
   xtal::SimpleStructure make_simple_structure(Supercell const &_scel,
                                               ConfigDoF const &_dof,
@@ -26,13 +38,13 @@ namespace CASM {
     return make_simple_structure(_config.supercell(), _config.configdof(), MappedProperties(), _which_dofs, false);
   }
 
-  SimpleStructure make_simple_structure(Supercell const &_scel,
-                                        ConfigDoF const &_dof,
-                                        MappedProperties const &_props,
-                                        std::vector<DoFKey> const &_which_dofs,
-                                        bool relaxed) {
+  xtal::SimpleStructure make_simple_structure(Supercell const &_scel,
+                                              ConfigDoF const &_dof,
+                                              MappedProperties const &_props,
+                                              std::vector<DoFKey> const &_which_dofs,
+                                              bool relaxed) {
 
-    SimpleStructure result;
+    xtal::SimpleStructure result;
 
     result.mol_info.resize(_dof.size());
     if(!relaxed) {
@@ -69,14 +81,14 @@ namespace CASM {
       }
     }
 
-    _apply_dofs(result, _dof, _scel.prim(), _which_dofs);
+    clex_SimpleStructureTools_impl::_apply_dofs(result, _dof, _scel.prim(), _which_dofs);
     return result;
   }
 
 
   //***************************************************************************
 
-  std::vector<std::set<Index> > mol_site_compatibility(SimpleStructure const &sstruc,
+  std::vector<std::set<Index> > mol_site_compatibility(xtal::SimpleStructure const &sstruc,
                                                        Configuration const &_config) {
     std::vector<std::set<Index> > result;
     result.reserve(sstruc.mol_info.names.size());
@@ -92,7 +104,7 @@ namespace CASM {
   }
 
 
-  std::vector<std::set<Index> > atom_site_compatibility(SimpleStructure const &sstruc,
+  std::vector<std::set<Index> > atom_site_compatibility(xtal::SimpleStructure const &sstruc,
                                                         Configuration const &_config) {
     std::vector<std::set<Index> > result;
     result.reserve(sstruc.atom_info.names.size());
@@ -107,83 +119,120 @@ namespace CASM {
     return result;
   }
 
-  //***************************************************************************
+  namespace clex_SimpleStructureTools_impl {
 
-  void _apply_dofs(SimpleStructure &_sstruc, ConfigDoF const &_config, BasicStructure const &_reference, std::vector<DoFKey> which_dofs) {
-    std::set<TransformDirective> tformers({TransformDirective("atomize")});
-    if(which_dofs.empty()) {
-      for(std::string const &dof : continuous_local_dof_types(_reference))
-        which_dofs.push_back(dof);
-      for(std::string const &dof : global_dof_types(_reference))
-        which_dofs.push_back(dof);
-    }
+    /// Class that helps manage which order DoF are applied to a SimpleStructure when building it
+    /// from a Configuration. Each TransformDirective applies one DoF type or "atomizes" molecules
+    /// (populating SimpleStructure::atom_info from SimpleStructure::mol_info). It is meant to be
+    /// stored in a std::set<TransformDirective> and has a comparison operator and uses information
+    /// from AnisoValTraits to appropriately order TransformDirective in the set. Then they can be
+    /// applied sequentially (using `transform`) to build the SimpleStructure.
+    class TransformDirective {
+    public:
 
-    for(DoFKey const &dof : which_dofs) {
-      if(dof != "none" && dof != "occ")
-        tformers.insert(dof);
-    }
+      /// \brief consturct from transformation or DoF type name
+      TransformDirective(std::string const &_name);
 
-    for(TransformDirective const &tformer : tformers) {
-      tformer.transform(_config, _reference, _sstruc);
-    }
-  }
-
-  TransformDirective::TransformDirective(std::string const &_name) :
-    m_name(_name),
-    m_traits_ptr(nullptr) {
-    if(name() != "atomize") {
-      m_traits_ptr = &DoFType::traits(name());
-      _accumulate_before({_name}, m_before);
-      _accumulate_after({_name}, m_after);
-      if(m_after.count("atomize") == 0)
-        m_before.insert("atomize");
-
-    }
-  }
-
-  bool TransformDirective::operator<(TransformDirective const &_other) const {
-    if(m_before.count(_other.name()) || _other.m_after.count(name())) {
-      return false;
-    }
-    if(m_after.count(_other.name()) || _other.m_before.count(name())) {
-      return true;
-    }
-    return name() < _other.name();
-  }
-
-
-  void TransformDirective::_accumulate_before(std::set<std::string>const &_queue, std::set<std::string> &_result) const {
-    for(std::string const &el : _queue) {
-      if(el != name())
-        _result.insert(el);
-      if(el != "atomize")
-        _accumulate_before(AnisoValTraits(el).must_apply_before(), _result);
-    }
-  }
-
-
-  void TransformDirective::_accumulate_after(std::set<std::string>const &_queue, std::set<std::string> &_result) const {
-    for(std::string const &el : _queue) {
-      if(el != name())
-        _result.insert(el);
-      if(el != "atomize")
-        _accumulate_after(AnisoValTraits(el).must_apply_after(), _result);
-    }
-  }
-
-
-  void TransformDirective::transform(ConfigDoF const  &_dof, BasicStructure const &_reference, SimpleStructure &_struc) const {
-    if(m_traits_ptr) {
-      if(m_traits_ptr->val_traits().global())
-        _struc.properties[m_traits_ptr->name()] = _dof.global_dof(m_traits_ptr->name()).standard_values();
-      else {
-        _struc.mol_info.properties[m_traits_ptr->name()] = _dof.local_dof(m_traits_ptr->name()).standard_values();
+      /// \brief Name of DoFType or transformation
+      std::string const &name() const {
+        return m_name;
       }
-      m_traits_ptr->apply_dof(_dof, _reference, _struc);
+
+      /// \brief Compare with _other TransformDirective. Returns true if this TransformDirective has precedence
+      bool operator<(TransformDirective const &_other) const;
+
+      /// \brief Applies transformation to _struc using information contained in _config
+      void transform(ConfigDoF const  &_config, xtal::BasicStructure const &_reference, xtal::SimpleStructure &_struc) const;
+
+    private:
+      /// \brief Build m_before object by recursively traversing DoF dependencies
+      void _accumulate_before(std::set<std::string>const &_queue, std::set<std::string> &_result) const;
+
+      /// \brief Build m_after object by recursively traversing DoF dependencies
+      void _accumulate_after(std::set<std::string>const &_queue, std::set<std::string> &_result) const;
+
+      std::string m_name;
+      std::set<std::string> m_before;
+      std::set<std::string> m_after;
+
+      DoFType::Traits const *m_traits_ptr;
+    };
+
+    void _apply_dofs(xtal::SimpleStructure &_sstruc, ConfigDoF const &_config, xtal::BasicStructure const &_reference, std::vector<DoFKey> which_dofs) {
+      std::set<TransformDirective> tformers({TransformDirective("atomize")});
+      if(which_dofs.empty()) {
+        for(std::string const &dof : continuous_local_dof_types(_reference))
+          which_dofs.push_back(dof);
+        for(std::string const &dof : global_dof_types(_reference))
+          which_dofs.push_back(dof);
+      }
+
+      for(DoFKey const &dof : which_dofs) {
+        if(dof != "none" && dof != "occ")
+          tformers.insert(dof);
+      }
+
+      for(TransformDirective const &tformer : tformers) {
+        tformer.transform(_config, _reference, _sstruc);
+      }
     }
-    else {
-      _atomize(_struc, _dof.occupation(), _reference);
+
+    TransformDirective::TransformDirective(std::string const &_name) :
+      m_name(_name),
+      m_traits_ptr(nullptr) {
+      if(name() != "atomize") {
+        m_traits_ptr = &DoFType::traits(name());
+        _accumulate_before({_name}, m_before);
+        _accumulate_after({_name}, m_after);
+        if(m_after.count("atomize") == 0)
+          m_before.insert("atomize");
+
+      }
+    }
+
+    bool TransformDirective::operator<(TransformDirective const &_other) const {
+      if(m_before.count(_other.name()) || _other.m_after.count(name())) {
+        return false;
+      }
+      if(m_after.count(_other.name()) || _other.m_before.count(name())) {
+        return true;
+      }
+      return name() < _other.name();
+    }
+
+
+    void TransformDirective::_accumulate_before(std::set<std::string>const &_queue, std::set<std::string> &_result) const {
+      for(std::string const &el : _queue) {
+        if(el != name())
+          _result.insert(el);
+        if(el != "atomize")
+          _accumulate_before(AnisoValTraits(el).must_apply_before(), _result);
+      }
+    }
+
+
+    void TransformDirective::_accumulate_after(std::set<std::string>const &_queue, std::set<std::string> &_result) const {
+      for(std::string const &el : _queue) {
+        if(el != name())
+          _result.insert(el);
+        if(el != "atomize")
+          _accumulate_after(AnisoValTraits(el).must_apply_after(), _result);
+      }
+    }
+
+
+    void TransformDirective::transform(ConfigDoF const  &_dof, xtal::BasicStructure const &_reference, xtal::SimpleStructure &_struc) const {
+      if(m_traits_ptr) {
+        if(m_traits_ptr->val_traits().global())
+          _struc.properties[m_traits_ptr->name()] = _dof.global_dof(m_traits_ptr->name()).standard_values();
+        else {
+          _struc.mol_info.properties[m_traits_ptr->name()] = _dof.local_dof(m_traits_ptr->name()).standard_values();
+        }
+        m_traits_ptr->apply_dof(_dof, _reference, _struc);
+      }
+      else {
+        _atomize(_struc, _dof.occupation(), _reference);
+      }
     }
   }
-
 }

--- a/src/casm/clex/SupercellIO.cc
+++ b/src/casm/clex/SupercellIO.cc
@@ -473,4 +473,10 @@ namespace CASM {
     return dict;
   }
 
+  template<>
+  DataFormatterDictionary<Supercell, BaseValueFormatter<jsonParser, Supercell>> make_json_dictionary<Supercell>() {
+    return DataFormatterDictionary<Supercell, BaseValueFormatter<jsonParser, Supercell>>();
+  }
+
+
 }

--- a/src/casm/clex/io/json/ConfigDoF_json_io.cc
+++ b/src/casm/clex/io/json/ConfigDoF_json_io.cc
@@ -37,40 +37,148 @@ namespace CASM {
 
 
   std::unique_ptr<ConfigDoF> jsonMake<ConfigDoF>::make_from_json(
-    const jsonParser &json, Structure const &structure) {
+    const jsonParser &json, Structure const &prim) {
 
-    auto result_ptr = notstd::make_unique<ConfigDoF>((Index) structure.basis().size(), 0,
-                                                     global_dof_info(structure), local_dof_info(structure), structure.occupant_symrep_IDs(),
-                                                     structure.lattice().tol());
+    auto result_ptr = notstd::make_unique<ConfigDoF>((Index) prim.basis().size(), 0,
+                                                     global_dof_info(prim), local_dof_info(prim), prim.occupant_symrep_IDs(),
+                                                     prim.lattice().tol());
     result_ptr->from_json(json);
     return result_ptr;
   }
 
-  // ConfigDoF jsonConstructor<ConfigDoF>::from_json(
-  //   const jsonParser &json, Index NB, std::map<DoFKey, DoFSetInfo> const &global_info,
-  //   std::map<DoFKey, std::vector<DoFSetInfo> > const &local_info,
-  //   std::vector<SymGroupRepID> const &_occ_symrep_IDs, double _tol) {
-  //
-  //   ConfigDoF result(NB, 0, global_info, local_info,  _occ_symrep_IDs, _tol);
-  //   result.from_json(json);
-  //
-  //   return result;
-  // }
+  ConfigDoF jsonConstructor<ConfigDoF>::from_json(const jsonParser &json, Structure const &prim) {
 
-  ConfigDoF jsonConstructor<ConfigDoF>::from_json(const jsonParser &json, Structure const &structure) {
-
-    ConfigDoF result {(Index) structure.basis().size(), 0, global_dof_info(structure),
-                      local_dof_info(structure), structure.occupant_symrep_IDs(), structure.lattice().tol()};
+    ConfigDoF result {(Index) prim.basis().size(), 0, global_dof_info(prim),
+                      local_dof_info(prim), prim.occupant_symrep_IDs(), prim.lattice().tol()};
     result.from_json(json);
     return result;
   }
 
-  jsonParser &to_json(const ConfigDoF &value, jsonParser &json) {
-    return value.to_json(json);
+  /// Insert ConfigDoF to JSON
+  ///
+  /// Format:
+  /// \code
+  /// {
+  ///   "occ": <array of integer>,
+  ///   "global_dofs": {
+  ///     <dof_name>: {
+  ///       "values": <1d array of numbers, DoF values in standard basis>
+  ///     },
+  ///     ...
+  ///   },
+  ///   "local_dofs": {
+  ///     <dof_name>: {
+  ///       "values": <2d array of numbers, DoF values in standard basis>
+  ///     },
+  ///     ...
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// Reminder about standard DoF basis vs prim DoF basis:
+  /// - Each type of DoF refers to an AnisoValTraits object which contains the "standard" DoF basis
+  /// - The prim BasicStructure holds xtal::SiteDoFSet (representing local DoF) and xtal::DoFSet
+  ///   (representing global DoF) which contain an AnisoValTraits object and a separate "prim" DoF
+  ///   basis containing a set of named basis vectors which are denoted relative to the standard
+  ///   basis, allowing the user to specify the DoFSet components, name them, and restrict DoF
+  ///   values to a particular subspace.
+  /// - Examples of standard DoF basis specified by AnisoValTraits:
+  ///   - "disp" -> (dx, dy, dz) -> displacement components relative to fixed laboratory frame
+  ///   - "strain" -> (e_xx, e_yy, e_zz, sqrt(2)*e_yz, sqrt(2)*e_xz, sqrt(2)*e_xy) -> tensor elements
+  /// - ConfigDoF objects in memory store DoF values as coordinates in the prim DoF basis
+  /// - ConfigDoF JSON representation stores DoF values as coordinates in the standard DoF basis
+  ///
+  /// Note:
+  /// - "occ":
+  ///       The integer value for each site corresponding to which Molecule in the
+  ///       Site::occupant_dof vector is occupying that site.
+  ///
+  ///       Example: supercell volume=3, prim basis size=2,
+  ///
+  ///           "occ": [
+  ///               occ[1], // "occ" value on site sublattice 0, unit cell 0
+  ///               occ[2], // "occ" value on site sublattice 0, unit cell 1
+  ///               occ[3], // "occ" value on site sublattice 0, unit cell 2
+  ///               occ[4], // "occ" value on site sublattice 1, unit cell 0
+  ///               occ[5], // "occ" value on site sublattice 1, unit cell 1
+  ///               occ[6]  // "occ" value on site sublattice 1, unit cell 2
+  ///             ]
+  ///
+  /// - "local_dofs":
+  ///       The local DoF values are represented as a matrix, with each row representing a site DoF
+  ///       value and each colum representing a component of the DoF value:
+  ///           number of cols = DoF dimension (i.e. 3 for "disp")
+  ///           number of rows = (Supercell volume as multiple of the prim) * (prim basis size).
+  ///
+  ///       Example: "disp" values, supercell volume=3, prim basis size=2
+  ///
+  ///           "local_dofs": {
+  ///             "disp": {
+  ///               "values": [
+  ///                 [dx[1], dy[1], dz[1]], // "disp" values on site: sublattice 0, unit cell 0
+  ///                 [dx[2], dy[2], dz[2]], // "disp" values on site: sublattice 0, unit cell 1
+  ///                 [dx[3], dy[3], dz[3]], // "disp" values on site: sublattice 0, unit cell 2
+  ///                 [dx[4], dy[4], dz[4]], // "disp" values on site: sublattice 1, unit cell 0
+  ///                 [dx[5], dy[5], dz[5]], // "disp" values on site: sublattice 1, unit cell 1
+  ///                 [dx[6], dy[6], dz[6]], // "disp" values on site: sublattice 1, unit cell 2
+  ///               ]
+  ///             }
+  ///           }
+  ///
+  /// - "global_dofs":
+  ///       The global DoF values are represented as a vector of size equal to the dimension of the
+  ///       DoF (i.e. 6 for "GLstrain").
+  ///
+  ///       Example: "GLstrain" values (any supercell volume and prim basis size)
+  ///
+  ///           "global_dofs": {
+  ///             "GLstrain": {
+  ///               "values": [Exx, Eyy, Ezz, sqrt(2)Exz, sqrt(2)Eyz, sqrt(2)Exy]
+  ///             }
+  ///           }
+  ///
+  jsonParser &to_json(const ConfigDoF &configdof, jsonParser &json) {
+    json = jsonParser::object();
+    if(configdof.occupation().size())
+      to_json_array(configdof.occupation(), json["occ"]);
+    if(!configdof.local_dofs().empty()) {
+      json["local_dofs"] = configdof.local_dofs();
+    }
+    if(!configdof.global_dofs().empty()) {
+      json["global_dofs"] = configdof.global_dofs();
+    }
+
+    return json;
   }
 
-  void from_json(ConfigDoF &value, const jsonParser &json) { //, Index NB) {
-    value.from_json(json);
+  /// Read ConfigDoF from JSON
+  void from_json(ConfigDoF &configdof, const jsonParser &json) {
+
+    if(json.contains("occupation")) {
+      // //For Backwards compatibility
+      configdof.set_occupation(json["occupation"].get<LocalDiscreteConfigDoFValues>().values());
+    }
+    else if(json.contains("occ")) {
+      configdof.set_occupation(json["occ"].get<LocalDiscreteConfigDoFValues>().values());
+    }
+    else {
+      throw std::runtime_error("JSON serialization of ConfigDoF must contain field \"occ\"\n");
+    }
+
+
+    if(json.contains("local_dofs")) {
+      auto end_it = json["local_dofs"].end();
+      for(auto it = json["local_dofs"].begin(); it != end_it; ++it) {
+        CASM::from_json(configdof.local_dof(it.name()), *it);
+      }
+    }
+
+    if(json.contains("global_dofs")) {
+      auto end_it = json["global_dofs"].end();
+      for(auto it = json["global_dofs"].begin(); it != end_it; ++it) {
+        CASM::from_json(configdof.global_dof(it.name()), *it);
+      }
+    }
   }
 
 }

--- a/src/casm/clex/io/json/Configuration_json_io.cc
+++ b/src/casm/clex/io/json/Configuration_json_io.cc
@@ -1,0 +1,116 @@
+#include "casm/casm_io/Log.hh"
+#include "casm/casm_io/container/json_io.hh"
+#include "casm/casm_io/json/InputParser_impl.hh"
+#include "casm/clex/ConfigDoF.hh"
+#include "casm/clex/ConfigDoFTools.hh"
+#include "casm/clex/Configuration.hh"
+#include "casm/clex/Supercell.hh"
+#include "casm/clex/io/json/ConfigDoF_json_io.hh"
+#include "casm/clex/io/json/Configuration_json_io.hh"
+
+namespace CASM {
+
+  /// Read Configuration from JSON
+  ///
+  /// See `from_json(Configuration &configuration, jsonParser const &json)` for details.
+  Configuration jsonConstructor<Configuration>::from_json(
+    jsonParser const &json,
+    std::shared_ptr<const Structure> const &shared_prim) {
+    return std::move(*jsonMake<Configuration>::make_from_json(json, shared_prim));
+  }
+
+  /// Read Configuration from JSON
+  ///
+  /// See `from_json(Configuration &configuration, jsonParser const &json)` for details.
+  std::unique_ptr<Configuration> jsonMake<Configuration>::make_from_json(
+    jsonParser const &json,
+    std::shared_ptr<const Structure> const &shared_prim) {
+
+    auto &log = CASM::log();
+    ParentInputParser parser {json};
+    std::runtime_error error_if_invalid {"Error reading Configuration from JSON input"};
+
+    Eigen::Matrix3l T;
+    parser.require(T, "transformation_matrix_to_supercell");
+    report_and_throw_if_invalid(parser, log, error_if_invalid);
+    auto shared_supercell = std::make_shared<Supercell const>(shared_prim, T);
+
+    ConfigDoF configdof = make_configdof(*shared_prim, T.determinant());
+    parser.optional(configdof, "dof");
+
+    if(configdof.n_vol() != shared_supercell->volume()) {
+      std::stringstream msg;
+      msg << "Error reading Configuration from JSON: "
+          << "supercell size (" << shared_supercell->volume() << ") and "
+          << "configdof size (" << configdof.n_vol() << ") are inconsistent.";
+      msg << "supercell_name: " << json["supercell_name"].get<std::string>();
+      parser.error.insert(msg.str());
+    }
+    report_and_throw_if_invalid(parser, log, error_if_invalid);
+
+    return notstd::make_unique<Configuration>(shared_supercell, configdof);
+  }
+
+  /// Insert Configuration to JSON
+  ///
+  /// Format:
+  /// \code
+  /// {
+  ///   "supercell_name": <string>,
+  ///   "transformation_matrix_to_supercell": <3x3 array of integer>,
+  ///   "dof": <JSON object representation of ConfigDoF>
+  /// }
+  /// \endcode
+  ///
+  /// Note:
+  /// - "supercell_name": string
+  ///       The name of the supercell. If the supercell is in canonical form, the name has the
+  ///       format "SCELV_A_B_C_D_E_F", where V is the integer supercell volume (multiple of the
+  ///       primitive cell), and "A_B_C_D_E_F" are integer values of the hermite normal form of the
+  ///       "transformation_matrix_to_supercell". If the supercell is not in canonical form, the
+  ///       name has the format "SCELV_A_B_C_D_E_F.FG_INDEX", where FG_INDEX is the index in the
+  ///       prim factor group of an operation that transforms the canonical form to the particular
+  ///       supercell.
+  /// - "transformation_matrix_to_supercell": 3x3 array of integer
+  ///       The integer transformation matrix T such that S = P*T, where P is a 3x3 column vector
+  ///       matrix of the prim lattice vectors and S is a 3x3 column vector matrix of the supercell
+  ///       lattice vectors.
+  /// - "dof": JSON object representation of ConfigDoF
+  ///       See `to_json(ConfigDoF const &configdof, jsonParser &json)` for details.
+  jsonParser &to_json(Configuration const &configuration, jsonParser &json) {
+    if(!json.is_obj()) {
+      throw std::runtime_error("Error inserting configuration to json: not an object");
+    }
+    Supercell const &supercell = configuration.supercell();
+    SupercellSymInfo const &sym_info = supercell.sym_info();
+    json["supercell_name"] = supercell.name();
+    json["transformation_matrix_to_supercell"] = sym_info.transformation_matrix_to_super();
+    json["dof"] = configuration.configdof();
+    // TODO: include properties, cache, source?
+
+    return json;
+  }
+
+  /// Read Configuration from JSON
+  ///
+  /// Note:
+  /// - See `to_json(Configuration const &configuration, jsonParser &json)` for expected format.
+  /// - The attribute "transformation_matrix_to_super" must be present. If "supercell_name" is
+  ///   present it is ignored.
+  /// - The constructed Configuration is not necessarily canonical, nor is its Supercell.
+  /// - The constructed Configuration has a shared Supercell (`std::shared_ptr<Supercell const>`)
+  ///   that is not owned by any Supercell database.
+  /// - Use `DB::in_canonical_supercell` to make the canonical equivalent configuration with the
+  ///   canonical supercell from the Supercell database, without inserting the configuration in the
+  ///   Configuration database.
+  /// - Use `DB::make_canonical_and_insert` to make the equivalent configuration with the canonical
+  ///   supercell from the Supercell database and insert the canonical equivalent configuration in
+  ///   the Configuration database.
+  ///
+  void from_json(Configuration &configuration, jsonParser const &json) {
+    configuration = jsonConstructor<Configuration>::from_json(json, configuration.supercell().shared_prim());
+    // TODO: include properties, cache, source?
+  }
+
+
+}

--- a/src/casm/clex/io/stream/Configuration_stream_io.cc
+++ b/src/casm/clex/io/stream/Configuration_stream_io.cc
@@ -1,0 +1,14 @@
+#include "casm/crystallography/io/VaspIO.hh"
+#include "casm/clex/Configuration.hh"
+#include "casm/clex/SimpleStructureTools.hh"
+#include "casm/clex/io/stream/Configuration_stream_io.hh"
+
+namespace CASM {
+
+  void print_poscar(Configuration const &configuration, std::ostream &sout) {
+    VaspIO::PrintPOSCAR p {make_simple_structure(configuration), configuration.name()};
+    p.sort();
+    p.print(sout);
+  }
+
+}

--- a/src/casm/database/Selected.cc
+++ b/src/casm/database/Selected.cc
@@ -48,6 +48,9 @@ namespace CASM {
 
     template<typename ObjType>
     bool Selected<ObjType>::evaluate(const ObjType &_obj) const {
+      if(_obj.name().find("equiv") != std::string::npos) {
+        return false;
+      }
       return m_selection->is_selected(_obj.name());
     }
 

--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -1,88 +1,425 @@
-#include "casm/enumerator/DoFSpace.hh"
+#include "casm/clex/Configuration.hh"
 #include "casm/clex/Supercell.hh"
 #include "casm/crystallography/Structure.hh"
+#include "casm/enumerator/DoFSpace_impl.hh"
 #include "casm/symmetry/SupercellSymInfo_impl.hh"
-#include "casm/symmetry/SymRepTools.hh"
+
 namespace CASM {
 
-  //Initializes DoF subspace to identity, if empty matrix is provided
-  DoFSpace::DoFSpace(ConfigEnumInput _config_region,
-                     DoFKey _dof_key,
-                     Eigen::MatrixXd _dof_subspace) :
-    config_region(std::move(_config_region)),
-    dof_key(_dof_key) {
+  namespace DoFSpace_impl {
 
-    Index dof_space_dimension = get_dof_space_dimension(
-                                  _dof_key,
-                                  config_region.configuration(),
-                                  config_region.sites());
+    void throw_if_missing_local_dof_requirements(
+      DoFKey const &dof_key,
+      std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+      std::optional<std::set<Index>> const &sites) {
 
-    if(dof_subspace.size() == 0)
-      dof_subspace.setIdentity(dof_space_dimension, dof_space_dimension);
-    if(dof_subspace.rows() != dof_space_dimension) {
-      throw std::runtime_error("Attempting to construct DoFSpace with " + std::to_string(dof_subspace.rows())
-                               + " but " + std::to_string(dof_space_dimension) + " rows are required.");
-    }
+      if(!transformation_matrix_to_super.has_value() || !sites.has_value()) {
+        std::stringstream msg;
+        msg << "Error: local DoF '" << dof_key
+            << "' require transformation_matrix_to_super and sites" << std::endl;
+        throw std::runtime_error(msg.str());
 
-  }
-
-  Index get_dof_space_dimension(DoFKey dof_key,
-                                Configuration const &configuration,
-                                std::set<Index> const &sites) {
-
-    Index dof_space_dimension = 0;
-    auto const &supercell = configuration.supercell();
-    auto const &configdof = configuration.configdof();
-
-    if(AnisoValTraits(dof_key).global()) {
-      dof_space_dimension = configdof.global_dof(dof_key).dim();
-    }
-    else if(dof_key == "occ") {
-      std::vector<int> max_occ = supercell.max_allowed_occupation();
-      for(Index i : sites) {
-        dof_space_dimension += max_occ[i] + 1;
       }
     }
-    else {
-      dof_space_dimension = configdof.local_dof(dof_key).dim() * sites.size();
-    }
-    return dof_space_dimension;
+
   }
 
-  /// Return a vector<std::string> with DoF component descriptions
+  /// DoFSpace constructor
   ///
-  /// Note:
-  /// - Site DoF components are written with site index using a "beginning from 1" convention
-  ///   - For example: if single DoF component per site with name "dx", and "sites" is {0, 2}, the
-  ///     output is: {"dx[1]", "dx[3]"}
-  std::vector<std::string> make_axis_glossary(DoFKey dof_key,
-                                              Configuration const &configuration,
-                                              std::set<Index> const &sites) {
+  /// \param _shared_prim The prim structure
+  /// \param _dof_key The DoF type
+  /// \param _transformation_matrix_to_super Specifies the supercell for a local DoF space. Required
+  ///        for local DoF. Ignored for global DoF.
+  /// \param _sites The sites included in a local DoF space. For local DoF, default value if none
+  ///        given is all sites in the supercell. Ignored for global DoF.
+  /// \param _basis The DoFSpace basis, as a column vector matrix. May be a subspace (cols <= rows).
+  ///        If no value, will be set to identity matrix of dimension matching result of
+  ///        `get_dof_space_dimension`. If has value, dimension must match result of
+  ///        `get_dof_space_dimension`.
+  ///
+  DoFSpace::DoFSpace(
+    std::shared_ptr<Structure const> const &_shared_prim,
+    DoFKey const &_dof_key,
+    std::optional<Eigen::Matrix3l> const &_transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &_sites,
+    std::optional<Eigen::MatrixXd> const &_basis):
+    m_shared_prim(_shared_prim),
+    m_dof_key(_dof_key),
+    m_transformation_matrix_to_super(_transformation_matrix_to_super),
+    m_sites(_sites) {
 
-    xtal::BasicStructure const &prim_struc = configuration.prim().structure();
-
-    // The axis_glossary gives names un-symmetrized coordinate system
-    // It will be populated based on whether the DoF is global or local
-    std::vector<std::string> axis_glossary;
-
-    if(prim_struc.global_dofs().count(dof_key)) {
-      // Global DoF, axis_glossary comes straight from the DoF
-      axis_glossary = component_descriptions(prim_struc.global_dof(dof_key));
+    if(AnisoValTraits(m_dof_key).global()) {
+      m_transformation_matrix_to_super.reset();
+      m_sites.reset();
     }
     else {
-      // Generate full axis_glossary for all active sites of the config_region
-      for(Index site_index : sites) {
-        Index sublattice_index = configuration.sublat(site_index);
-        xtal::Site const &site = prim_struc.basis()[sublattice_index];
-        if(!site.dofs().count(dof_key))
-          continue;
-        std::vector<std::string> tdescs = component_descriptions(site.dof(dof_key));
-        for(std::string const &desc : tdescs) {
-          axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) + "]");
+      if(!m_transformation_matrix_to_super.has_value()) {
+        std::stringstream msg;
+        msg << "Error constructing DoFSpace: Local DoF '" << m_dof_key
+            << "' requires transformation_matrix_to_super." << std::endl;
+        throw std::runtime_error(msg.str());
+      }
+      if(!m_sites.has_value()) {
+        xtal::UnitCellCoordIndexConverter unitcellcoord_index_converter(*transformation_matrix_to_super(),
+                                                                        shared_prim()->basis().size());
+        m_sites = std::set<Index>();
+        for(Index i = 0; i < unitcellcoord_index_converter.total_sites(); ++i) {
+          m_sites->insert(i);
         }
       }
     }
+
+    Index dof_space_dimension = get_dof_space_dimension(dof_key(),
+                                                        *shared_prim(),
+                                                        transformation_matrix_to_super(),
+                                                        sites());
+
+    if(!_basis.has_value()) {
+      m_basis = Eigen::MatrixXd::Identity(dof_space_dimension, dof_space_dimension);
+    }
+    else {
+      m_basis = _basis.value();
+    }
+    if(m_basis.rows() != dof_space_dimension) {
+      std::stringstream msg;
+      msg << "Error constructing DoFSpace: # basis rows (" << m_basis.rows()
+          << ") != expected dimension (" << dof_space_dimension << ").";
+      throw std::runtime_error(msg.str());
+    }
+    if(m_basis.cols() > m_basis.rows()) {
+      std::stringstream msg;
+      msg << "Error constructing DoFSpace: # basis columns (" << m_basis.cols()
+          << ") > expected dimension (" << m_basis.rows() << ").";
+      throw std::runtime_error(msg.str());
+    }
+    m_basis_inverse = m_basis.inverse();
+    make_dof_space_axis_info(dof_key(),
+                             *shared_prim(),
+                             transformation_matrix_to_super(),
+                             sites(),
+                             m_axis_glossary,
+                             m_axis_site_index,
+                             m_axis_dof_component);
+  }
+
+  /// Shared prim structure
+  std::shared_ptr<Structure const> const &DoFSpace::shared_prim() const {
+    return m_shared_prim;
+  }
+
+  /// Type of degree of freedom that is under consideration (e.g., "disp", "Hstrain", "occ")
+  DoFKey const &DoFSpace::dof_key() const {
+    return m_dof_key;
+  }
+
+  /// Specifies the supercell for a local DoF space. Has value for local DoF.
+  std::optional<Eigen::Matrix3l> const &DoFSpace::transformation_matrix_to_super() const {
+    return m_transformation_matrix_to_super;
+  }
+
+  /// The sites included in a local DoF space. Has value for local DoF.
+  std::optional<std::set<Index>> const &DoFSpace::sites() const {
+    return m_sites;
+  }
+
+  /// The DoF space basis, as a column vector matrix. May be a subspace (cols <= rows).
+  Eigen::MatrixXd const &DoFSpace::basis() const {
+    return m_basis;
+  }
+
+  /// The DoF space dimensions (equals to number of rows in basis).
+  Index DoFSpace::dim() const {
+    return m_basis.rows();
+  }
+
+  /// The DoF subspace dimension (equal to number of columns in basis).
+  Index DoFSpace::subspace_dim() const {
+    return m_basis.cols();
+  }
+
+  /// The inverse of the DoF space basis.
+  Eigen::MatrixXd const &DoFSpace::basis_inverse() const {
+    return m_basis_inverse;
+  }
+
+  /// Names the DoF corresponding to each dimension (row) of the basis
+  std::vector<std::string> const &DoFSpace::axis_glossary() const {
+    return m_axis_glossary;
+  }
+
+  /// The supercell site_index corresponding to each dimension (row) of the basis. Has value for
+  /// local DoF.
+  std::optional<std::vector<Index>> const &DoFSpace::axis_site_index() const {
+    return m_axis_site_index;
+  }
+
+  /// The local DoF site DoFSet component index corresponding to each dimension (row) of the
+  /// basis. Has value for local DoF.
+  std::optional<std::vector<Index>> const &DoFSpace::axis_dof_component() const {
+    return m_axis_dof_component;
+  }
+
+
+  /// Return true if `dof_space` is valid for `config`
+  ///
+  /// Checks that:
+  /// - The prim are equivalent
+  /// - For local DoF, that the transformation_matrix_to_super are equivalent
+  bool is_valid_dof_space(Configuration const &config, DoFSpace const &dof_space) {
+
+    if(!AnisoValTraits(dof_space.dof_key()).global()) {
+      if(config.supercell().shared_prim() != dof_space.shared_prim()) {
+        return false;
+      }
+      if(config.supercell().sym_info().transformation_matrix_to_super() != dof_space.transformation_matrix_to_super()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Throw if `!is_valid_dof_space(config, dof_space)`
+  void throw_if_invalid_dof_space(Configuration const &config, DoFSpace const &dof_space) {
+    if(!is_valid_dof_space(config, dof_space)) {
+      std::stringstream msg;
+      msg << "Error: DoFSpace is not valid for given configuration." << std::endl;
+      throw std::runtime_error(msg.str());
+    }
+  }
+
+  /// Return `config` DoF value as a coordinate in the DoFSpace basis
+  Eigen::VectorXd get_normal_coordinate(Configuration const &config, DoFSpace const &dof_space) {
+    using namespace DoFSpace_impl;
+    throw_if_invalid_dof_space(config, dof_space);
+
+    auto const &dof_key = dof_space.dof_key();
+    auto const &basis_inverse = dof_space.basis_inverse();
+
+    if(AnisoValTraits(dof_key).global()) {
+      return basis_inverse * config.configdof().global_dof(dof_key).values();
+    }
+    else {
+      if(dof_key == "occ") {
+        return basis_inverse * config.configdof().occupation().cast<double>();
+      }
+      else {
+
+        Eigen::VectorXd vector_values = Eigen::VectorXd::Zero(dof_space.dim());
+        Eigen::MatrixXd const &matrix_values = config.configdof().local_dof(dof_key).values();
+
+        auto const &axis_dof_component = dof_space.axis_dof_component().value();
+        auto const &axis_site_index = dof_space.axis_site_index().value();
+
+        for(Index i = 0; i < dof_space.dim(); ++i) {
+          vector_values[i] = matrix_values(axis_dof_component[i], axis_site_index[i]);
+        }
+        return basis_inverse * vector_values;
+      }
+    }
+  }
+
+  /// Set `config` DoF value from a coordinate in the DoFSpace basis
+  void set_dof_value(Configuration &config,
+                     DoFSpace const &dof_space,
+                     Eigen::VectorXd const &normal_coordinate) {
+    using namespace DoFSpace_impl;
+    throw_if_invalid_dof_space(config, dof_space);
+
+    if(normal_coordinate.size() != dof_space.subspace_dim()) {
+      std::stringstream msg;
+      msg << "Error in set_dof_value: normal coordinate size (" << normal_coordinate.size()
+          << ") != # basis axes (" << dof_space.subspace_dim() << ").";
+      throw std::runtime_error(msg.str());
+    }
+
+    auto const &dof_key = dof_space.dof_key();
+    auto const &basis = dof_space.basis();
+
+    if(AnisoValTraits(dof_key).global()) {
+      config.configdof().set_global_dof(dof_key, basis * normal_coordinate);
+    }
+    else {
+
+      if(dof_key == "occ") {
+        std::stringstream msg;
+        msg << "Error: set_dof_value is not supported for occupation." << std::endl;
+        throw std::runtime_error(msg.str());
+      }
+
+      Eigen::VectorXd vector_values = basis * normal_coordinate;
+      Eigen::MatrixXd &matrix_values = config.configdof().local_dof(dof_key).values();
+
+      auto const &axis_dof_component = dof_space.axis_dof_component().value();
+      auto const &axis_site_index = dof_space.axis_site_index().value();
+
+      for(Index i = 0; i < dof_space.dim(); ++i) {
+        matrix_values(axis_dof_component[i], axis_site_index[i]) = vector_values[i];
+      }
+    }
+  }
+
+  Index get_dof_space_dimension(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites) {
+    if(AnisoValTraits(dof_key).global()) {
+      return prim.global_dof(dof_key).dim();
+    }
+    else {
+      using namespace DoFSpace_impl;
+      throw_if_missing_local_dof_requirements(dof_key, transformation_matrix_to_super, sites);
+
+      xtal::UnitCellCoordIndexConverter unitcellcoord_index_converter(*transformation_matrix_to_super,
+                                                                      prim.basis().size());
+      Index dof_space_dimension = 0;
+      for(Index site_index : *sites) {
+        Index sublattice_index = unitcellcoord_index_converter(site_index).sublattice();
+        xtal::Site const &site = prim.basis()[sublattice_index];
+        if(dof_key == "occ") {
+          dof_space_dimension += site.occupant_dof().size();
+        }
+        else if(site.has_dof(dof_key)) {
+          dof_space_dimension += site.dof(dof_key).dim();
+        }
+      }
+      return dof_space_dimension;
+    }
+  }
+
+  /// The axis_glossary gives names to an un-symmetrized coordinate system
+  std::vector<std::string> make_axis_glossary(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites) {
+
+    std::vector<std::string> axis_glossary;
+
+    if(AnisoValTraits(dof_key).global()) {
+      // Global DoF, axis_glossary comes straight from the DoF
+      axis_glossary = component_descriptions(prim.global_dof(dof_key));
+    }
+    else {
+      using namespace DoFSpace_impl;
+      throw_if_missing_local_dof_requirements(dof_key, transformation_matrix_to_super, sites);
+
+      xtal::UnitCellCoordIndexConverter unitcellcoord_index_converter(*transformation_matrix_to_super,
+                                                                      prim.basis().size());
+      // Generate full axis_glossary for all active sites of the config_region
+      for(Index site_index : *sites) {
+        Index sublattice_index = unitcellcoord_index_converter(site_index).sublattice();
+        xtal::Site const &site = prim.basis()[sublattice_index];
+        if(dof_key == "occ") {
+          for(auto const &molecule : site.occupant_dof()) {
+            axis_glossary.push_back("occ[" + std::to_string(site_index + 1) + "][" + molecule.name() + "]");
+          }
+        }
+        else if(site.has_dof(dof_key)) {
+          std::vector<std::string> tdescs = component_descriptions(site.dof(dof_key));
+          for(std::string const &desc : tdescs) {
+            axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) + "]");
+          }
+        }
+        if(!site.has_dof(dof_key))
+          continue;
+      }
+    }
     return axis_glossary;
+  }
+
+  /// The axis_glossary gives names to an un-symmetrized coordinate system
+  void make_dof_space_axis_info(
+    DoFKey dof_key,
+    xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites,
+    std::vector<std::string> &axis_glossary,
+    std::optional<std::vector<Index>> &axis_site_index,
+    std::optional<std::vector<Index>> &axis_dof_component) {
+
+    if(AnisoValTraits(dof_key).global()) {
+      axis_glossary.clear();
+      axis_site_index = std::nullopt;
+      axis_dof_component = std::nullopt;
+
+      // Global DoF, axis_glossary comes straight from the DoF
+      axis_glossary = component_descriptions(prim.global_dof(dof_key));
+    }
+    else {
+      using namespace DoFSpace_impl;
+      throw_if_missing_local_dof_requirements(dof_key, transformation_matrix_to_super, sites);
+
+      axis_glossary.clear();
+      axis_site_index = std::vector<Index>();
+      axis_dof_component = std::vector<Index>();
+
+      xtal::UnitCellCoordIndexConverter unitcellcoord_index_converter(*transformation_matrix_to_super,
+                                                                      prim.basis().size());
+      // Generate full axis_glossary for all active sites of the config_region
+      for(Index site_index : *sites) {
+        Index sublattice_index = unitcellcoord_index_converter(site_index).sublattice();
+        xtal::Site const &site = prim.basis()[sublattice_index];
+        if(dof_key == "occ") {
+          Index i = 0;
+          for(auto const &molecule : site.occupant_dof()) {
+            axis_glossary.push_back("occ[" + std::to_string(site_index + 1) + "][" + molecule.name() + "]");
+            axis_dof_component->push_back(i);
+            axis_site_index->push_back(site_index);
+            ++i;
+          }
+        }
+        else if(site.has_dof(dof_key)) {
+          std::vector<std::string> tdescs = component_descriptions(site.dof(dof_key));
+          Index i = 0;
+          for(std::string const &desc : tdescs) {
+            axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) + "]");
+            axis_dof_component->push_back(i);
+            axis_site_index->push_back(site_index);
+            ++i;
+          }
+        }
+        if(!site.has_dof(dof_key))
+          continue;
+      }
+    }
+  }
+
+  /// Make DoFSpace using `dof_key`, transformation matrix and sites from `input_state`, and `basis`
+  DoFSpace make_dof_space(DoFKey dof_key,
+                          ConfigEnumInput const &input_state,
+                          std::optional<Eigen::MatrixXd> const &basis) {
+
+    auto const &supercell = input_state.configuration().supercell();
+
+    return DoFSpace(
+             supercell.shared_prim(),
+             dof_key,
+             supercell.sym_info().transformation_matrix_to_super(),
+             input_state.sites(),
+             basis);
+  }
+
+  /// Make DoFSpace with symmetry adapated basis
+  DoFSpace make_symmetry_adapted_dof_space(
+    DoFSpace const &dof_space,
+    ConfigEnumInput const &input_state,
+    std::vector<PermuteIterator> const &group,
+    bool calc_wedges,
+    std::optional<VectorSpaceSymReport> &symmetry_report) {
+
+    symmetry_report = vector_space_sym_report(dof_space, input_state, group.begin(), group.end(), calc_wedges);
+
+    // check for error occuring for "disp"
+    if(symmetry_report->symmetry_adapted_dof_subspace.cols() < dof_space.basis().cols()) {
+
+      std::stringstream msg;
+      msg << "Error in make_symmetry_adapted_dof_space: "
+          << "symmetry_adapted_dof_subspace.cols() < dof_space.basis().cols()";
+      throw make_symmetry_adapted_dof_space_error(msg.str());
+    }
+
+    return make_dof_space(dof_space.dof_key(), input_state, symmetry_report->symmetry_adapted_dof_subspace);
   }
 
 }

--- a/src/casm/enumerator/io/dof_space_analysis.cc
+++ b/src/casm/enumerator/io/dof_space_analysis.cc
@@ -1,0 +1,348 @@
+#include <boost/filesystem.hpp>
+#include "casm/app/AppIO.hh"
+#include "casm/app/DirectoryStructure.hh"
+#include "casm/casm_io/Log.hh"
+#include "casm/clex/SimpleStructureTools.hh"
+#include "casm/crystallography/SimpleStructure.hh"
+#include "casm/crystallography/io/SimpleStructureIO.hh"
+#include "casm/enumerator/ConfigEnumInput.hh"
+#include "casm/enumerator/DoFSpace_impl.hh"
+#include "casm/enumerator/io/dof_space_analysis.hh"
+#include "casm/enumerator/io/json/DoFSpace.hh"
+#include "casm/global/definitions.hh"
+#include "casm/symmetry/io/json/SymRepTools.hh"
+
+namespace CASM {
+
+  namespace DoFSpaceIO {
+
+    /// Write symmetry groups (lattice point group, factor_group, crystal_point_group)
+    void OutputImpl::write_symmetry(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input,
+      std::vector<PermuteIterator> const &group) {
+      Lattice config_lattice = config_enum_input.configuration().ideal_lattice();
+      SymGroup lattice_point_group {SymGroup::lattice_point_group(config_lattice)};
+      SymGroup factor_group = make_sym_group(group.begin(), group.end(), config_lattice);
+      SymGroup crystal_point_group = make_point_group(group.begin(), group.end(), config_lattice);
+      this->write_symmetry(
+        state_index,
+        identifier,
+        config_enum_input,
+        lattice_point_group,
+        factor_group,
+        crystal_point_group);
+    }
+
+    void DirectoryOutput::write_symmetry(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input,
+      SymGroup const &lattice_point_group,
+      SymGroup const &factor_group,
+      SymGroup const &crystal_point_group) {
+
+      _check_config(state_index, identifier, config_enum_input);
+      fs::path output_dir = _output_dir(state_index, identifier, config_enum_input);
+
+      // Write lattice point group
+      {
+        jsonParser json;
+        write_symgroup(lattice_point_group, json);
+        fs::path output_path = output_dir / "lattice_point_group.json";
+        fs::ofstream outfile {output_path};
+        json.print(outfile);
+        CASM::log() << "Writing: " << output_path << std::endl;
+      }
+
+      // Write factor group
+      {
+        jsonParser json;
+        write_symgroup(factor_group, json);
+        fs::path output_path = output_dir / "factor_group.json";
+        fs::ofstream outfile {output_path};
+        json.print(outfile);
+        CASM::log() << "Writing: " << output_path << std::endl;
+      }
+
+      // Write crystal point group
+      {
+        jsonParser json;
+        write_symgroup(crystal_point_group, json);
+        fs::path output_path = output_dir / "crystal_point_group.json";
+        fs::ofstream outfile {output_path};
+        json.print(outfile);
+        CASM::log() << "Writing: " << output_path << std::endl;
+      }
+    }
+
+    // void DirectoryOutput::write_config(
+    //   Index state_index,
+    //   std::string const &identifier,
+    //   ConfigEnumInput const &config_enum_input) {
+    //
+    //   _check_config(state_index, identifier, config_enum_input);
+    //   fs::path output_dir = _output_dir(state_index, identifier, config_enum_input);
+    //
+    //   fs::path output_path = output_dir / "config.json";
+    //   fs::ofstream outfile {output_path};
+    //   jsonParser json;
+    //   to_json(config_enum_input.configuration(), json);
+    //   json.print(outfile);
+    //   CASM::log() << "Writing: " << output_path << std::endl << std::endl;
+    // }
+
+    void DirectoryOutput::write_structure(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+
+      _check_config(state_index, identifier, config_enum_input);
+      fs::path output_dir = _output_dir(state_index, identifier, config_enum_input);
+
+      fs::path output_path = output_dir / "structure.json";
+      fs::ofstream outfile {output_path};
+      jsonParser json;
+      to_json(make_simple_structure(config_enum_input.configuration()), json);
+      json.print(outfile);
+      CASM::log() << "Writing: " << output_path << std::endl << std::endl;
+    }
+
+    void DirectoryOutput::write_dof_space(
+      Index state_index,
+      DoFSpace const &dof_space,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input,
+      std::optional<VectorSpaceSymReport> const &sym_report) {
+
+      _check_config(state_index, identifier, config_enum_input);
+      fs::path output_dir = _output_dir(state_index, identifier, config_enum_input);
+
+      jsonParser json;
+      to_json(dof_space, json, identifier, config_enum_input, sym_report);
+
+      std::string filename = "dof_space_" + dof_space.dof_key() + ".json";
+      fs::path output_path = output_dir / filename;
+      json.write(output_path);
+      CASM::log() << "Writing: " << output_path << std::endl << std::endl;
+
+    }
+
+
+    SymmetryDirectoryOutput::SymmetryDirectoryOutput(DirectoryStructure const &dir):
+      m_dir(dir) {}
+
+    /// For SymmetryDirectoryOutput, configurations must exist in database and this will throw otherwise
+    void SymmetryDirectoryOutput::_check_config(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+
+      Configuration const &configuration = config_enum_input.configuration();
+      // These should not occur for now. They should be prevented by require_database_configurations.
+      // TODO: add support for other dof space analyses
+      if(configuration.id() == "none") {
+        throw std::runtime_error("Error in output_dof_space: Cannot output to symmetry directory, "
+                                 "configuration does not exist in database. Choose a different output method.");
+      }
+      if(identifier != configuration.name()) {
+        throw std::runtime_error("Error in output_dof_space: Cannot output to symmetry directory, "
+                                 "unknown name error. Choose a different output method.");
+      }
+      if(config_enum_input.sites().size() != configuration.size()) {
+        throw std::runtime_error("Error in output_dof_space: Cannot output to symmetry directory, "
+                                 "incomplete site selection. Choose a different output method.");
+      }
+    }
+
+    /// For SymmetryDirectoryOutput return output directory path in symmetry dir
+    fs::path SymmetryDirectoryOutput::_output_dir(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+      fs::path output_dir = m_dir.symmetry_dir(config_enum_input.configuration().name());
+      fs::create_directories(output_dir);
+      return output_dir;
+    }
+
+
+    SequentialDirectoryOutput::SequentialDirectoryOutput(fs::path output_dir):
+      m_output_dir(output_dir) {
+      if(fs::exists(m_output_dir / "dof_space")) {
+        throw std::runtime_error("Error in output_dof_space: \"dof_space\" directory "
+                                 "already exists. Will not overwrite.");
+      }
+    }
+
+    /// For SequentialDirectoryOutput, any input state is allowed
+    void SequentialDirectoryOutput::_check_config(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+      return;
+    }
+
+    /// For SequentialDirectoryOutput return output directory path
+    fs::path SequentialDirectoryOutput::_output_dir(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+      std::string dirname = std::string("state.") + std::to_string(state_index);
+      fs::path output_dir = m_output_dir / "dof_space" / dirname;
+      fs::create_directories(output_dir);
+      return output_dir;
+    }
+
+
+    CombinedJsonOutput::CombinedJsonOutput(fs::path output_dir):
+      m_combined_json(jsonParser::array()),
+      m_output_dir(output_dir) {
+      fs::path output_path = m_output_dir / "dof_space.json";
+      if(fs::exists(output_path)) {
+        throw std::runtime_error("Error in output_dof_space: \"dof_space.json\" file "
+                                 "already exists. Will not overwrite.");
+      }
+    }
+
+    CombinedJsonOutput::~CombinedJsonOutput() {
+      fs::path output_path = m_output_dir / "dof_space.json";
+      fs::ofstream outfile {output_path};
+      m_combined_json.print(outfile);
+      CASM::log() << "Writing: " << output_path << std::endl;
+    }
+
+    void CombinedJsonOutput::write_symmetry(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input,
+      SymGroup const &lattice_point_group,
+      SymGroup const &factor_group,
+      SymGroup const &crystal_point_group) {
+
+      jsonParser &output_json = _output_json(state_index);
+      write_symgroup(lattice_point_group, output_json["lattice_point_group"]);
+      write_symgroup(factor_group, output_json["factor_group"]);
+      write_symgroup(crystal_point_group, output_json["crystal_point_group"]);
+    }
+
+    // void CombinedJsonOutput::write_config(
+    //   Index state_index,
+    //   std::string const &identifier,
+    //   ConfigEnumInput const &config_enum_input) {
+    //
+    //   jsonParser &output_json = _output_json(state_index);
+    //   to_json(config_enum_input.configuration(), output_json["config"]);
+    // }
+
+    void CombinedJsonOutput::write_structure(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input) {
+
+      jsonParser &output_json = _output_json(state_index);
+      to_json(make_simple_structure(config_enum_input.configuration()), output_json["structure"]);
+    }
+
+    void CombinedJsonOutput::write_dof_space(
+      Index state_index,
+      DoFSpace const &dof_space,
+      std::string const &identifier,
+      ConfigEnumInput const &config_enum_input,
+      std::optional<VectorSpaceSymReport> const &sym_report) {
+
+      jsonParser &output_json = _output_json(state_index)["dof_space"][dof_space.dof_key()];
+      to_json(dof_space, output_json, identifier, config_enum_input, sym_report);
+
+    }
+
+    jsonParser &CombinedJsonOutput::_output_json(Index state_index) {
+      while(m_combined_json.size() < state_index) {
+        m_combined_json.push_back(jsonParser::object());
+      }
+      return m_combined_json[state_index - 1];
+    }
+
+    void output_dof_space(
+      Index state_index,
+      std::string const &identifier,
+      ConfigEnumInput const &input_state,
+      DoFSpaceAnalysisOptions const &options,
+      OutputImpl &output) {
+
+      Log &log = CASM::log();
+      log.begin(identifier);
+      log.increase_indent();
+
+      std::vector<PermuteIterator> group = make_invariant_subgroup(input_state);
+
+      if(options.write_symmetry) {
+        Lattice config_lattice = input_state.configuration().ideal_lattice();
+        SymGroup lattice_point_group {SymGroup::lattice_point_group(config_lattice)};
+        SymGroup factor_group = make_sym_group(group.begin(), group.end(), config_lattice);
+        SymGroup crystal_point_group = make_point_group(group.begin(), group.end(), config_lattice);
+        output.write_symmetry(
+          state_index,
+          identifier,
+          input_state,
+          lattice_point_group,
+          factor_group,
+          crystal_point_group);
+      }
+
+      // if(options.write_config) {
+      //   output.write_config(state_index, identifier, config_enum_input);
+      // }
+
+      if(options.write_structure) {
+        output.write_structure(state_index, identifier, input_state);
+      }
+
+      for(DoFKey const &dof : options.dofs) {
+        log << "Working on: " << identifier << " " << dof << std::endl;
+        DoFSpace dof_space = make_dof_space(dof, input_state);
+        std::optional<VectorSpaceSymReport> report;
+        try {
+          if(options.sym_axes) {
+            dof_space = make_symmetry_adapted_dof_space(
+                          dof_space, input_state, group, options.calc_wedge, report);
+          }
+        }
+        catch(make_symmetry_adapted_dof_space_error &e) {
+          log << e.what() << std::endl;
+          if(report.has_value()) {
+            jsonParser json;
+            to_json(*report, json);
+            log << json << std::endl;
+          }
+          log << "skipping: " << identifier << " " << dof << std::endl << std::endl;
+          continue;
+        }
+        output.write_dof_space(state_index, dof_space, identifier, input_state, report);
+      }
+
+      log.decrease_indent();
+      log << std::endl;
+    }
+
+
+    void dof_space_analysis(
+      std::vector<std::pair<std::string, ConfigEnumInput>> const &named_inputs,
+      DoFSpaceAnalysisOptions const &options,
+      OutputImpl &output) {
+
+      // For each state, for each DoF type specified, perform analysis and write files.
+      Index state_index {0};
+      for(auto const &named_input : named_inputs) {
+
+        std::string identifier = named_input.first;
+        ConfigEnumInput const &input_state = named_input.second;
+        output_dof_space(state_index, identifier, input_state, options, output);
+
+        ++state_index;
+      }
+    }
+
+  }
+
+}

--- a/tests/functional/FCC_NiAl_Hstrain_enumeration/run.sh.in
+++ b/tests/functional/FCC_NiAl_Hstrain_enumeration/run.sh.in
@@ -91,7 +91,7 @@ casm query -k "scel_size comp_n point_group_name multiplicity"
 casm sym --dof-space-analysis --dofs Hstrain --confignames SCEL4_2_2_1_1_1_0/0 > /dev/null
 
 # Check: There should be a strain analysis file now
-STRAIN_ANALYIS=symmetry/analysis/SCEL4_2_2_1_1_1_0/0/dof_analysis_Hstrain.json
+STRAIN_ANALYIS=symmetry/analysis/SCEL4_2_2_1_1_1_0/0/dof_space_Hstrain.json
 if [ ! -e $STRAIN_ANALYIS ]; then
     echo "Expected to find $STRAIN_ANALYIS"
     exit 2

--- a/tests/unit/App/enum_methods_ConfigEnumStrainInterface_test.cpp
+++ b/tests/unit/App/enum_methods_ConfigEnumStrainInterface_test.cpp
@@ -78,6 +78,7 @@ TEST_F(enum_methods_ConfigEnumStrainInterfaceTest, Test1) {
   CASM::log().set_verbosity(Log::debug);
 
   {
+    fs::path test_dir = test::proj_dir(primclex.dir().root_dir() / "ConfigEnumStrainInterfaceTest");
     std::string cli_str = "casm enum --method ConfigEnumStrain";
     jsonParser json_options;
     json_options["max"] = 0.11;
@@ -85,6 +86,7 @@ TEST_F(enum_methods_ConfigEnumStrainInterfaceTest, Test1) {
     json_options["trim_corners"] = false;
     json_options["scelnames"] = std::vector<std::string> {"SCEL1_1_1_1_0_0_0"};
     json_options["output_configurations"] = true;
+    json_options["output_dir"] = test_dir.string();
     test::run_enum_interface<ConfigEnumStrainInterface>(cli_str, primclex, json_options);
     EXPECT_EQ(primclex.db<Configuration>().size(), 20);
   }

--- a/tests/unit/examples/202_enumeration_ConfigEnumStrain_test.cpp
+++ b/tests/unit/examples/202_enumeration_ConfigEnumStrain_test.cpp
@@ -193,12 +193,13 @@ TEST_F(ExampleEnumerationSimpleCubicConfigEnumStrain, VectorSpaceSymReport) {
   std::cout << "here 3" << std::endl;
   DoFKey dof_key = "GLstrain";
   std::cout << "here 4" << std::endl;
-  DoFSpace dof_space {config_input, dof_key};
+  DoFSpace dof_space = make_dof_space(dof_key, config_input);
 
   // Construct the VectorSpaceSymReport for the SimpleCubic GLstrain space.
   std::cout << "here 5" << std::endl;
   bool calc_wedges = true;  // explanation TODO
   VectorSpaceSymReport sym_report = vector_space_sym_report(dof_space,
+                                                            config_input,
                                                             group.begin(),
                                                             group.end(),
                                                             calc_wedges);


### PR DESCRIPTION
This PR:

- Changes the DoFSpace class:
  - Now it only includes the DoF space information (dof_key, (optional) supercell transformation matrix and sites, subspace) and not the configuration / symmetry information
  - Includes a shared prim
  - Additional glossary / DoF indexing information
  - Adds (standalone) methods that make use of DoFSpace to convert to/from ConfigDoF values and normal coordinates

- Updates Configuration / ConfigDoF / DoFSpace JSON IO:
  - Improves separation of IO code 
  - Changes the DoFSpace JSON output:
    - Stores the input state with standard ConfigDoF JSON output
    - Adds `"axis_state_index"` and `"axis_dof_component"`
    - Optional inclusion of VectorSpaceSymReport and input state (ConfigEnumInput and identifier string) info
  - Adds DoFSpace JSON input
  - Adds a method for doing DoFSpace symmetry analysis with any input state, and not just canonical configurations existing in the database:
    - The `casm sym --dof-space-analysis` method now accepts all of the input state options that `casm enum` accepts (`"confignames", "config_selection", "scelnames", "supercell_selection", "supercells", "sublats", "sites", "cluster_specs"` plus an new option `"config_list"` allowing configurations to be specified by all DoF values explicitly)
    - Three `"output_type"` options are accepted: 
      - `"symmetry_directory"` (default, previous behavior)
      - `"sequential"`, output to sequentially indexed directories for each input state
      - `"combined_json"`, output combined as a list in one JSON file
  - Continuous DoF enumerators output the DoFSpace as with the `"sequential"` output type so that it can be read for subsequent analysis
  - Adds `Configuration` JSON IO
  - Changes the existing standard `config.json` file to `structure.json` so that `SimpleStructure` output (structure representation) is in `structure.json` file and  `Configuration` JSON output (explict DoF values)  is in `config.json`