### PR TITLE
1.0.X configdof

### DIFF
--- a/include/casm/app/EnumeratorHandler_impl.hh
+++ b/include/casm/app/EnumeratorHandler_impl.hh
@@ -59,7 +59,6 @@ load_enumerator_plugins(ProjectSettings const &set,
         std::string msg =
             "compiling new custom enumerator: " + f_s.substr(0, f_size - 3);
 
-        // '-L$CASM_PREFIX/.libs' is a hack so 'make check' works
         auto lib_ptr = log_make_shared_runtime_lib(
             p_s.substr(0, p_size - 3),
             set.compile_options() + " " +

--- a/include/casm/app/HamiltonianModules_impl.hh
+++ b/include/casm/app/HamiltonianModules_impl.hh
@@ -40,7 +40,6 @@ std::pair<DoFDictInserter, RuntimeLibInserter> load_dof_plugins(
         std::string msg = "Compiling new custom DoFTraits for DoF: " +
                           f_s.substr(0, f_size - 3);
 
-        // '-L$CASM_PREFIX/.libs' is a hack so 'make check' works
         auto lib_ptr = log_make_shared_runtime_lib(
             p_s.substr(0, p_size - 3),
             set.compile_options() + " " + include_path(dir.dof_plugins()),

--- a/include/casm/clex/Clexulator.hh
+++ b/include/casm/clex/Clexulator.hh
@@ -409,10 +409,9 @@ class Base {
   /// \brief The weight matrix used for ordering the neighbor list
   PrimNeighborList::Matrix3Type m_weight_matrix;
 
-  mutable std::vector<ConfigDoF::LocalDoFContainerType const *>
-      m_local_dof_ptrs;
+  mutable std::vector<LocalContinuousConfigDoFValues const *> m_local_dof_ptrs;
 
-  mutable std::vector<ConfigDoF::GlobalDoFContainerType const *>
+  mutable std::vector<GlobalContinuousConfigDoFValues const *>
       m_global_dof_ptrs;
 
  private:

--- a/include/casm/clex/ConfigDoFTools.hh
+++ b/include/casm/clex/ConfigDoFTools.hh
@@ -1,15 +1,42 @@
 #ifndef CASM_clex_ConfigDoFTools
 #define CASM_clex_ConfigDoFTools
 
+#include <memory>
+
 #include "casm/global/definitions.hh"
 
 namespace CASM {
 
 class ConfigDoF;
 class Structure;
+class Supercell;
 
 /// Construct zero-valued ConfigDoF
 ConfigDoF make_configdof(Structure const &prim, Index volume);
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Structure const &prim, Index volume, double tol);
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Structure const &prim,
+                                                 Index volume);
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Structure const &prim,
+                                                 Index volume, double tol);
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Supercell const &supercell);
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Supercell const &supercell, double tol);
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Supercell const &supercell);
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Supercell const &supercell,
+                                                 double tol);
 
 }  // namespace CASM
 

--- a/include/casm/clex/ConfigDoF_impl.hh
+++ b/include/casm/clex/ConfigDoF_impl.hh
@@ -1,0 +1,63 @@
+#ifndef CASM_clex_ConfigDoF_impl
+#define CASM_clex_ConfigDoF_impl
+
+#include <vector>
+
+#include "casm/clex/ConfigDoF.hh"
+
+namespace CASM {
+
+/// ConfigDoF constructor
+///
+/// \param _N_sublat Number of sublattices in corresponding prim
+/// \param _N_vol Supercell volume, as multiples of the prim volume
+/// \param global_dof_info GlobalInfoContainerType is an iterable container of
+///        value_type std::pair<DoFKey,ContinuousDoFInfo>.
+/// \param local_dof_info LocalInfoContainerType is an iterable container of
+///        value_type std::pair<DoFKey,std::vector<ContinuousDoFInfo>  >
+//
+/// Note: Typically Structure has already been included when a ConfigDoF is
+/// constructed, in which case it is best to use `make_configdof` from
+/// clex/ConfigDoFTools.hh.
+///
+template <typename GlobalInfoContainerType, typename LocalInfoContainerType>
+ConfigDoF::ConfigDoF(Index _N_sublat, Index _N_vol,
+                     GlobalInfoContainerType const &global_dof_info,
+                     LocalInfoContainerType const &local_dof_info,
+                     std::vector<SymGroupRepID> const &occ_symrep_IDs,
+                     double _tol)
+    : m_occupation(DoF::BasicTraits("occ"), _N_sublat, _N_vol, occ_symrep_IDs),
+      m_tol(_tol) {
+  for (auto const &dof : global_dof_info) {
+    DoF::BasicTraits ttraits(dof.first);
+
+    if (!ttraits.global())
+      throw std::runtime_error(
+          "Attempting to initialize ConfigDoF global value using local DoF " +
+          dof.first);
+    m_global_dofs.emplace(
+        dof.first, GlobalContinuousConfigDoFValues(ttraits, _N_sublat, _N_vol,
+                                                   dof.second));
+  }
+  for (auto const &dof : local_dof_info) {
+    DoF::BasicTraits ttraits(dof.first);
+    if (_N_sublat == 0) continue;
+    if (ttraits.global())
+      throw std::runtime_error(
+          "Attempting to initialize ConfigDoF local value using global DoF " +
+          dof.first);
+    if (_N_sublat != dof.second.size()) {
+      throw std::runtime_error(
+          "Attempting to initialize ConfigDoF local value '" + dof.first +
+          "' with improperly initialized parameter 'local_dof_info'.");
+    }
+
+    m_local_dofs.emplace(
+        dof.first,
+        LocalContinuousConfigDoFValues(ttraits, _N_sublat, _N_vol, dof.second));
+  }
+}
+
+}  // namespace CASM
+
+#endif

--- a/include/casm/clex/ConfigEnumRandomLocal.hh
+++ b/include/casm/clex/ConfigEnumRandomLocal.hh
@@ -76,7 +76,7 @@ class ConfigEnumRandomLocal : public InputEnumeratorBase<Configuration> {
   // Number of configurations to be enumerated
   Index m_n_config;
 
-  ConfigDoF::LocalDoFContainerType *m_dof_vals;
+  LocalContinuousConfigDoFValues *m_dof_vals;
 
   // Pseudo-random number generator
   MTRand &m_mtrand;

--- a/include/casm/clex/ConfigEnumRandomOccupations.hh
+++ b/include/casm/clex/ConfigEnumRandomOccupations.hh
@@ -64,7 +64,7 @@ class ConfigEnumRandomOccupations : public InputEnumeratorBase<Configuration> {
 
   Index m_n_config;
   MTRand &m_mtrand;
-  std::vector<int> m_max_allowed;
+  Eigen::VectorXi m_max_allowed;
   std::vector<Index> m_site_selection;
   notstd::cloneable_ptr<Configuration> m_current;
 };

--- a/include/casm/clex/ConfigEnumSiteDoFs.hh
+++ b/include/casm/clex/ConfigEnumSiteDoFs.hh
@@ -147,7 +147,7 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
   // -- Unique -------------------
   notstd::cloneable_ptr<Configuration> m_current;
 
-  ConfigDoF::LocalDoFContainerType *m_dof_vals;
+  LocalContinuousConfigDoFValues *m_dof_vals;
 
   DoFKey m_dof_key;
 

--- a/include/casm/clex/Configuration.hh
+++ b/include/casm/clex/Configuration.hh
@@ -75,8 +75,6 @@ class Configuration : public ConfigurationBase {
  public:
   //********* CONSTRUCTORS *********
 
-  // Configuration() {};
-
   /// Construct a default Configuration, with a shared Supercell
   ///
   /// Note:
@@ -114,15 +112,10 @@ class Configuration : public ConfigurationBase {
       const std::shared_ptr<Supercell const> &_supercell_ptr, double _tol);
 
   // *** The following constructors should be avoided in new code, if possible
-  // ***
   //
-  //     They are currently still required in enumerators and similar code when
-  //     the Configuration uses a Supercell from a Database<Supercell> and/or
-  //     Configuration "source" information is required and cannot be stored
-  //     another way. In the future:
+  //     They are currently still required in some code. In the future:
   //     - Configuration will make exclusive use of std::shared_ptr<Supercell
   //     const>
-  //     - The "source" information will be stored outside of Configuration
   //     - The jsonConstructor<Configuration>::from_json method will be used to
   //       construct Configuration from JSON
 
@@ -133,10 +126,7 @@ class Configuration : public ConfigurationBase {
   /// - This constructor keeps a pointer to _supercell, whose lifetime must
   /// exceed the lifetime
   ///   of this Configuration
-  /// - In the future, "source" information will be stored outside of
-  /// Configuration.
-  explicit Configuration(Supercell const &_supercell,
-                         jsonParser const &source = jsonParser());
+  explicit Configuration(Supercell const &_supercell);
 
   /// Construct a default Configuration
   ///
@@ -145,63 +135,7 @@ class Configuration : public ConfigurationBase {
   /// - This constructor keeps a pointer to _supercell, whose lifetime must
   /// exceed the lifetime
   ///   of this Configuration
-  /// - In the future, "source" information will be stored outside of
-  /// Configuration.
-  explicit Configuration(const Supercell &_supercell, const jsonParser &source,
-                         const ConfigDoF &_dof);
-
-  /// Construct a default Configuration that owns its Supercell
-  ///
-  /// Note:
-  /// - Whenever possible, this constructor should not be used in new code .
-  /// - This Configuration does own its own Supercell, so the lifetime of the
-  /// Supercell is
-  ///   guaranteed to exceed the lifetime of this Configuration
-  /// - In the future, "source" information will be stored outside of
-  /// Configuration.
-  explicit Configuration(const std::shared_ptr<Supercell const> &_supercell,
-                         const jsonParser &source);
-
-  /// Construct a default Configuration that owns its Supercell
-  ///
-  /// Note:
-  /// - Whenever possible, this constructor should not be used in new code .
-  /// - This Configuration does own its own Supercell, so the lifetime of the
-  /// Supercell is
-  ///   guaranteed to exceed the lifetime of this Configuration
-  /// - In the future, "source" information will be stored outside of
-  /// Configuration.
-  explicit Configuration(const std::shared_ptr<Supercell const> &_supercell,
-                         const jsonParser &source, const ConfigDoF &_dof);
-
-  /// Construct a Configuration from JSON data
-  ///
-  /// Note:
-  /// - Whenever possible, this constructor should not be used in new code .
-  /// - This constructor keeps a pointer to _supercell, whose lifetime must
-  /// exceed the lifetime
-  ///   of this Configuration
-  /// - This constructor sets the "id" of this Configuration.
-  /// - In the future, a Configuration will not be constructed directly from
-  /// JSON in favor of
-  ///   using the "from_json" method.
-  Configuration(const Supercell &_supercell, const std::string &_id,
-                const jsonParser &_data);
-
-  /// Construct a Configuration from JSON data
-  ///
-  /// Note:
-  /// - Whenever possible, this constructor should not be used in new code .
-  /// - This constructor uses "_configname" to lookup the correct Supercell from
-  /// the
-  ///   Database<Supercell> and uses that to construct this Configuration.
-  ///  - This constructor also uses the "_configname" to set the "id" of this
-  ///  Configuration.
-  /// - In the future, a Configuration will not be constructed directly from
-  /// JSON in favor of
-  ///   using the "from_json" method.
-  Configuration(const PrimClex &_primclex, const std::string &_configname,
-                const jsonParser &_data);
+  explicit Configuration(const Supercell &_supercell, const ConfigDoF &_dof);
 
   /// Build a Configuration sized to _scel with all fields initialized and set
   /// to zero
@@ -283,8 +217,7 @@ class Configuration : public ConfigurationBase {
   /// set_occupation ensures that ConfigDoF::size() is compatible with
   /// _occupation.size() or if ConfigDoF::size()==0, sets ConfigDoF::size() to
   /// _occupation.size()
-  template <typename OtherOccContainerType>
-  void set_occupation(const OtherOccContainerType &_occupation) {
+  void set_occupation(Eigen::Ref<const Eigen::VectorXi> const &_occupation) {
     configdof().set_occupation(_occupation);
   }
 
@@ -300,9 +233,7 @@ class Configuration : public ConfigurationBase {
   /// to the occupant DoF in a "prim.json" file. This means that for the
   /// background structure, 'occupation' is all 0
   ///
-  ConfigDoF::OccValueType const &occupation() const {
-    return configdof().occupation();
-  }
+  Eigen::VectorXi const &occupation() const { return configdof().occupation(); }
 
   /// \brief Set occupant variable on site l
   ///
@@ -438,16 +369,16 @@ class Configuration : public ConfigurationBase {
   /// database
   ConfigInsertResult insert(bool primitive_only = false) const;
 
-  /// Writes the Configuration to JSON
-  jsonParser &to_json(jsonParser &json) const;
-
-  /// Reads the Configuration from JSON
-  void from_json(const jsonParser &json, const Supercell &scel,
-                 std::string _id);
-
-  /// Reads the Configuration from JSON
-  void from_json(const jsonParser &json, const PrimClex &primclex,
-                 std::string _configname);
+  // /// Writes the Configuration to JSON
+  // jsonParser &to_json(jsonParser &json) const;
+  //
+  // /// Reads the Configuration from JSON
+  // void from_json(const jsonParser &json, const Supercell &scel,
+  //                std::string _id);
+  //
+  // /// Reads the Configuration from JSON
+  // void from_json(const jsonParser &json, const PrimClex &primclex,
+  //                std::string _configname);
 
   /// \brief Split configuration name string into scelname and config id
   static std::pair<std::string, std::string> split_name(std::string configname);

--- a/include/casm/clex/Supercell.hh
+++ b/include/casm/clex/Supercell.hh
@@ -29,8 +29,6 @@ class ConfigIterator;
 class PermuteIterator;
 class PrimClex;
 class Clexulator;
-class ConfigDoF;
-class Configuration;
 class PrimNeighborList;
 class SuperNeighborList;
 class Structure;
@@ -39,10 +37,6 @@ namespace DB {
 template <typename T>
 class DatabaseIterator;
 }
-
-struct ConfigMapCompare {
-  bool operator()(const Configuration *A, const Configuration *B) const;
-};
 
 /** \defgroup Supercell
  *  \ingroup Clex
@@ -93,11 +87,7 @@ class Supercell
 
   /// \brief returns maximum allowed occupation bitstring -- used for
   /// initializing enumeration counters
-  std::vector<int> max_allowed_occupation() const;
-
-  /// \brief returns Supercell-compatible configdof with zeroed DoF values and
-  /// user-specified tolerance
-  ConfigDoF zero_configdof(double tol) const;
+  Eigen::VectorXi max_allowed_occupation() const;
 
   // **** Accessors ****
 

--- a/include/casm/clex/io/json/ConfigDoF_json_io.hh
+++ b/include/casm/clex/io/json/ConfigDoF_json_io.hh
@@ -10,41 +10,24 @@
 namespace CASM {
 
 class ConfigDoF;
-struct DoFSetInfo;
-class LocalDiscreteConfigDoFValues;
-class LocalContinuousConfigDoFValues;
-class GlobalContinuousConfigDoFValues;
 class Structure;
-class SymGroupRepID;
-template <typename T>
-struct jsonMake;
 template <typename T>
 struct jsonConstructor;
+template <typename T>
+struct jsonMake;
 class jsonParser;
-
-jsonParser &to_json(LocalDiscreteConfigDoFValues const &_values,
-                    jsonParser &_json);
-void from_json(LocalDiscreteConfigDoFValues &_values, jsonParser const &_json);
-
-jsonParser &to_json(LocalContinuousConfigDoFValues const &_values,
-                    jsonParser &_json);
-void from_json(LocalContinuousConfigDoFValues &_values,
-               jsonParser const &_json);
-
-jsonParser &to_json(GlobalContinuousConfigDoFValues const &_values,
-                    jsonParser &_json);
-void from_json(GlobalContinuousConfigDoFValues &_values,
-               jsonParser const &_json);
 
 template <>
 struct jsonMake<ConfigDoF> {
   static std::unique_ptr<ConfigDoF> make_from_json(const jsonParser &json,
-                                                   Structure const &prim);
+                                                   Structure const &prim,
+                                                   Index volume);
 };
 
 template <>
 struct jsonConstructor<ConfigDoF> {
-  static ConfigDoF from_json(jsonParser const &json, Structure const &prim);
+  static ConfigDoF from_json(jsonParser const &json, Structure const &prim,
+                             Index volume);
 };
 
 jsonParser &to_json(const ConfigDoF &configdof, jsonParser &json);

--- a/include/casm/clex/io/json/ConfigDoF_json_io.hh
+++ b/include/casm/clex/io/json/ConfigDoF_json_io.hh
@@ -2,6 +2,7 @@
 #define CASM_ConfigDoF_json_io
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include "casm/crystallography/DoFDecl.hh"

--- a/include/casm/clex/io/json/Configuration_json_io.hh
+++ b/include/casm/clex/io/json/Configuration_json_io.hh
@@ -1,6 +1,7 @@
 #ifndef CASM_clex_Configuration_json_io
 #define CASM_clex_Configuration_json_io
 
+#include <memory>
 #include <string>
 
 namespace CASM {

--- a/include/casm/clusterography/io/json/ClusterOrbits_json_io.hh
+++ b/include/casm/clusterography/io/json/ClusterOrbits_json_io.hh
@@ -2,6 +2,7 @@
 #define CASM_ClusterOrbits_json_io
 
 #include <memory>
+#include <vector>
 
 namespace CASM {
 

--- a/include/casm/database/Cache.hh
+++ b/include/casm/database/Cache.hh
@@ -31,6 +31,18 @@ class Cache {
     }
   }
 
+  /// Set the configuration cache as read from the database
+  void set_initial_cache(jsonParser const &_cache) {
+    m_cache = _cache;
+    m_cache_updated = false;
+  }
+
+  /// Upate the configuration cache
+  void update_cache(jsonParser const &_cache) {
+    m_cache = _cache;
+    m_cache_updated = true;
+  }
+
   /// Access the configuration cache, which will be saved in the database
   const jsonParser &cache() const { return m_cache; }
 

--- a/include/casm/database/Database.hh
+++ b/include/casm/database/Database.hh
@@ -293,6 +293,12 @@ class ValDatabase : public DatabaseBase {
 
   void write_aliases();
 
+  /// Only ValDatabase<ValueType> is allowed to do clear_name
+  template <typename _ValueType>
+  void clear_name(const _ValueType &obj) const {
+    obj.clear_name();
+  }
+
   /// Only ValDatabase<ValueType> is allowed to do a const id change
   template <typename _ValueType>
   void set_id(const _ValueType &obj, Index id) const {

--- a/include/casm/monte_carlo/MonteSettings.hh
+++ b/include/casm/monte_carlo/MonteSettings.hh
@@ -94,7 +94,7 @@ class MonteSettings : protected CASM::jsonParser {
   bool is_motif_configdof() const;
 
   /// \brief ConfigDoF to use as starting motif
-  ConfigDoF motif_configdof() const;
+  ConfigDoF motif_configdof(Index supercell_volume) const;
 
   /// \brief Path to ConfigDoF file to use as starting motif
   fs::path motif_configdof_path() const;

--- a/src/casm/clex/ConfigDoF.cc
+++ b/src/casm/clex/ConfigDoF.cc
@@ -1,48 +1,101 @@
-#include "casm/clex/ConfigDoF.hh"
-
 #include "casm/basis_set/Adapter.hh"
-#include "casm/casm_io/container/json_io.hh"
 #include "casm/clex/ConfigDoFValues.hh"
-#include "casm/clex/io/json/ConfigDoF_json_io.hh"
+#include "casm/clex/ConfigDoF_impl.hh"
 #include "casm/global/definitions.hh"
 #include "casm/symmetry/PermuteIterator.hh"
 #include "casm/symmetry/SymPermutation.hh"
 
 namespace CASM {
 
-//*******************************************************************************
+/// Number of sites in the ConfigDoF
+Index ConfigDoF::size() const { return occupation().size(); }
 
-void ConfigDoF::clear() {
-  m_occupation.values().setZero();
-  m_global_dofs.clear();
-  m_local_dofs.clear();
-}
+/// Integer volume of ConfigDoF
+Index ConfigDoF::n_vol() const { return m_occupation.n_vol(); }
 
-//*******************************************************************************
+/// Number of sublattices in ConfigDoF
+Index ConfigDoF::n_sublat() const { return m_occupation.n_sublat(); }
 
-void ConfigDoF::swap(ConfigDoF &RHS) {
-  std::swap(m_occupation, RHS.m_occupation);
-  std::swap(m_local_dofs, RHS.m_local_dofs);
-  std::swap(m_global_dofs, RHS.m_global_dofs);
-  std::swap(m_tol, RHS.m_tol);
-}
+/// Tolerance for comparison of continuous DoF values
+double ConfigDoF::tol() const { return m_tol; }
 
-//*******************************************************************************
-
-void ConfigDoF::set_local_dof(DoFKey const &_key,
-                              Eigen::Ref<const Eigen::MatrixXd> const &_val) {
-  auto it = m_local_dofs.find(_key);
-  if (it == m_local_dofs.end()) {
-    throw std::runtime_error(
-        "Attempting to assign local ConfigDoF values of type " + _key +
-        " but no such value type has been allocated.\n");
+/// Set all DoF values to zero
+void ConfigDoF::setZero() {
+  m_occupation.setZero();
+  for (auto &local_dof : m_local_dofs) {
+    local_dof.second.setZero();
   }
-  assert(_val.cols() == it->second.values().cols() &&
-         _val.rows() == it->second.values().rows());
-  it->second.values() = _val;
+  for (auto &global_dof : m_global_dofs) {
+    global_dof.second.setZero();
+  }
 }
-//*******************************************************************************
 
+/// Reference occupation value on site i
+int &ConfigDoF::occ(Index i) { return m_occupation.occ(i); }
+
+/// Const reference to occupation value on site i
+const int &ConfigDoF::occ(Index i) const { return m_occupation.values()[i]; }
+
+/// Set occupation values
+///
+/// \throws std::runtime_error ("Size mismatch in ConfigDoF::set_occupation...")
+/// if input vector size does not match current size
+void ConfigDoF::set_occupation(
+    Eigen::Ref<const Eigen::VectorXi> const &_occupation) {
+  if (occupation().size() != _occupation.size()) {
+    std::stringstream msg;
+    msg << "Size mismatch in ConfigDoF::set_occupation(): "
+        << "Expected size=" << occupation().size()
+        << ", received size=" << _occupation.size();
+    throw std::runtime_error(msg.str());
+  }
+  m_occupation.set_values(_occupation);
+}
+
+/// Const reference occupation values
+Eigen::VectorXi const &ConfigDoF::occupation() const {
+  return m_occupation.values();
+}
+
+bool ConfigDoF::has_occupation() const {
+  return size() != 0 && occupation().size() == size();
+}
+
+std::map<DoFKey, GlobalContinuousConfigDoFValues> const &
+ConfigDoF::global_dofs() const {
+  return m_global_dofs;
+}
+
+GlobalContinuousConfigDoFValues const &ConfigDoF::global_dof(
+    DoFKey const &_key) const {
+  auto it = m_global_dofs.find(_key);
+  if (it == m_global_dofs.end())
+    throw std::runtime_error(
+        "Attempting to access uninitialized ConfigDoF value for '" + _key +
+        "'");
+  return it->second;
+}
+
+GlobalContinuousConfigDoFValues &ConfigDoF::global_dof(DoFKey const &_key) {
+  auto it = m_global_dofs.find(_key);
+  if (it == m_global_dofs.end())
+    throw std::runtime_error(
+        "Attempting to access uninitialized ConfigDoF value for '" + _key +
+        "'");
+  return it->second;
+}
+
+bool ConfigDoF::has_global_dof(DoFKey const &_key) const {
+  return global_dofs().count(_key);
+}
+
+/// Set global continuous DoF values
+///
+/// \throws std::runtime_error ("Attempting to assign global ConfigDoF
+/// values...") if "_key" does not exist in global dofs
+///
+/// \throws std::runtime_error ("Size mismatch in ConfigDoF::set_global_dof...")
+/// if input vector size does not match current size
 void ConfigDoF::set_global_dof(DoFKey const &_key,
                                Eigen::Ref<const Eigen::VectorXd> const &_val) {
   auto it = m_global_dofs.find(_key);
@@ -51,18 +104,85 @@ void ConfigDoF::set_global_dof(DoFKey const &_key,
         "Attempting to assign global ConfigDoF values of type " + _key +
         " but no such value type has been allocated.\n");
   }
-  assert(_val.rows() == it->second.values().rows());
-  // std::cout << "SETTING " << _key << " to " << _val << "\n";
-  it->second.values() = _val;
-}
-//*******************************************************************************
+  if (it->second.values().size() != _val.size()) {
+    std::stringstream msg;
+    msg << "Size mismatch in ConfigDoF::set_global_dof(): "
+        << "For key=\"" << _key
+        << "\", expected size=" << it->second.values().size()
+        << ", received size=" << _val.size();
+    throw std::runtime_error(msg.str());
+  }
 
-// Calculate transformed ConfigDoF from PermuteIterator via
-//   *this = permute_iterator * (*this)
+  it->second.set_values(_val);
+}
+
+std::map<DoFKey, LocalContinuousConfigDoFValues> const &ConfigDoF::local_dofs()
+    const {
+  return m_local_dofs;
+}
+
+LocalContinuousConfigDoFValues const &ConfigDoF::local_dof(
+    DoFKey const &_key) const {
+  auto it = m_local_dofs.find(_key);
+  if (it == m_local_dofs.end())
+    throw std::runtime_error(
+        "Attempting to access uninitialized ConfigDoF value for '" + _key +
+        "'");
+  return it->second;
+}
+
+LocalContinuousConfigDoFValues &ConfigDoF::local_dof(DoFKey const &_key) {
+  auto it = m_local_dofs.find(_key);
+  if (it == m_local_dofs.end())
+    throw std::runtime_error(
+        "Attempting to access uninitialized ConfigDoF value for '" + _key +
+        "'");
+  return it->second;
+}
+
+bool ConfigDoF::has_local_dof(DoFKey const &_key) const {
+  return local_dofs().count(_key);
+}
+
+/// Set local continuous DoF values
+///
+/// \throws std::runtime_error ("Attempting to assign local ConfigDoF
+/// values...") if "_key" does not  exist in local dofs
+//
+/// \throws std::runtime_error ("Size mismatch in ConfigDoF::set_local_dof...")
+/// if input matrix size does not match current matrix size
+void ConfigDoF::set_local_dof(DoFKey const &_key,
+                              Eigen::Ref<const Eigen::MatrixXd> const &_val) {
+  auto it = m_local_dofs.find(_key);
+  if (it == m_local_dofs.end()) {
+    throw std::runtime_error(
+        "Attempting to assign local ConfigDoF values of type " + _key +
+        " but no such value type has been allocated.\n");
+  }
+
+  if (it->second.values().rows() != _val.rows() ||
+      it->second.values().cols() != _val.cols()) {
+    std::stringstream msg;
+    msg << "Size mismatch in ConfigDoF::set_local_dof(): "
+        << "For key=\"" << _key
+        << "\", expected rows=" << it->second.values().rows()
+        << ", received rows=" << _val.rows()
+        << ", expected cols=" << it->second.values().cols()
+        << ", received cols=" << _val.cols();
+    throw std::runtime_error(msg.str());
+  }
+
+  it->second.set_values(_val);
+}
+
+/// Update DoF values using the effect of symmetry, including permutation
+/// among sites
+///
+/// The effect is: *this = permute_iterator * (*this)
 ConfigDoF &ConfigDoF::apply_sym(PermuteIterator const &it) {
   for (auto &dof : m_global_dofs) {
-    dof.second.values() =
-        *(it.global_dof_rep(dof.first).MatrixXd()) * dof.second.values();
+    dof.second.set_values(*(it.global_dof_rep(dof.first).MatrixXd()) *
+                          dof.second.values());
   }
 
   Permutation tperm(it.combined_permute());
@@ -95,15 +215,13 @@ ConfigDoF &ConfigDoF::apply_sym(PermuteIterator const &it) {
   return *this;
 }
 
-//*******************************************************************************
-
-// Calculate transformed ConfigDoF from PermuteIterator, using only the effect
-// of symmetry on the value at each site
+/// Update DoF values using only the effect of symmetry on the value at each
+/// site, without permutation among sites
 ConfigDoF &ConfigDoF::apply_sym_no_permute(SymOp const &_op) {
   for (auto &dof : m_global_dofs) {
-    dof.second.values() =
+    dof.second.set_values(
         *(_op.representation(dof.second.info().symrep_ID()).MatrixXd()) *
-        dof.second.values();
+        dof.second.values());
   }
 
   if (occupation().size()) {
@@ -132,21 +250,12 @@ ConfigDoF &ConfigDoF::apply_sym_no_permute(SymOp const &_op) {
   return *this;
 }
 
-//*******************************************************************************
-
-/// This function is deprecated in favor of the standalone `to_json`
-jsonParser &ConfigDoF::to_json(jsonParser &json) const {
-  return CASM::to_json(*this, json);
+void ConfigDoF::swap(ConfigDoF &RHS) {
+  std::swap(m_occupation, RHS.m_occupation);
+  std::swap(m_local_dofs, RHS.m_local_dofs);
+  std::swap(m_global_dofs, RHS.m_global_dofs);
+  std::swap(m_tol, RHS.m_tol);
 }
-
-//*******************************************************************************
-
-/// This function is deprecated in favor of the standalone `from_json`
-void ConfigDoF::from_json(const jsonParser &json) {
-  CASM::from_json(*this, json);
-}
-
-//*******************************************************************************
 
 void swap(ConfigDoF &A, ConfigDoF &B) { A.swap(B); }
 

--- a/src/casm/clex/ConfigDoFTools.cc
+++ b/src/casm/clex/ConfigDoFTools.cc
@@ -1,4 +1,7 @@
-#include "casm/clex/ConfigDoF.hh"
+#include "casm/clex/ConfigDoFTools.hh"
+
+#include "casm/clex/ConfigDoF_impl.hh"
+#include "casm/clex/Supercell.hh"
 #include "casm/crystallography/Structure.hh"
 
 namespace CASM {
@@ -8,6 +11,49 @@ ConfigDoF make_configdof(Structure const &prim, Index volume) {
   return ConfigDoF(prim.basis().size(), volume, global_dof_info(prim),
                    local_dof_info(prim), prim.occupant_symrep_IDs(),
                    prim.lattice().tol());
+}
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Structure const &prim, Index volume, double tol) {
+  return ConfigDoF(prim.basis().size(), volume, global_dof_info(prim),
+                   local_dof_info(prim), prim.occupant_symrep_IDs(), tol);
+}
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Structure const &prim,
+                                                 Index volume) {
+  return notstd::make_unique<ConfigDoF>(
+      prim.basis().size(), volume, global_dof_info(prim), local_dof_info(prim),
+      prim.occupant_symrep_IDs(), prim.lattice().tol());
+}
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Structure const &prim,
+                                                 Index volume, double tol) {
+  return notstd::make_unique<ConfigDoF>(
+      prim.basis().size(), volume, global_dof_info(prim), local_dof_info(prim),
+      prim.occupant_symrep_IDs(), tol);
+}
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Supercell const &supercell) {
+  return make_configdof(supercell.prim(), supercell.volume());
+}
+
+/// Construct zero-valued ConfigDoF
+ConfigDoF make_configdof(Supercell const &supercell, double tol) {
+  return make_configdof(supercell.prim(), supercell.volume(), tol);
+}
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Supercell const &supercell) {
+  return make_unique_configdof(supercell.prim(), supercell.volume());
+}
+
+/// Construct zero-valued std::unique_ptr<ConfigDoF>
+std::unique_ptr<ConfigDoF> make_unique_configdof(Supercell const &supercell,
+                                                 double tol) {
+  return make_unique_configdof(supercell.prim(), supercell.volume(), tol);
 }
 
 }  // namespace CASM

--- a/src/casm/clex/ConfigDoFValues.cc
+++ b/src/casm/clex/ConfigDoFValues.cc
@@ -2,18 +2,313 @@
 
 namespace CASM {
 
+ConfigDoFValues::ConfigDoFValues(DoF::BasicTraits const &_traits,
+                                 Index _n_sublat, Index _n_vol)
+    : m_type(_traits.name()), m_n_sublat(_n_sublat), m_n_vol(_n_vol) {}
+
+std::string const &ConfigDoFValues::type_name() const { return m_type; }
+
+Index ConfigDoFValues::n_vol() const { return m_n_vol; }
+
+Index ConfigDoFValues::n_sublat() const { return m_n_sublat; }
+
+LocalDiscreteConfigDoFValues::LocalDiscreteConfigDoFValues(
+    DoF::BasicTraits const &_traits, Index _n_sublat, Index _n_vol,
+    std::vector<SymGroupRepID> const &_symrep_IDs)
+    : ConfigDoFValues(_traits, _n_sublat, _n_vol),
+      m_vals(Eigen::VectorXi::Zero(_n_sublat * _n_vol)),
+      m_symrep_IDs(_symrep_IDs) {}
+
+/// Reference occupation value on site i
+int &LocalDiscreteConfigDoFValues::occ(Index i) { return m_vals(i); }
+
+/// Set occupation values (values are indices into Site::occupant_dof())
+///
+/// \throws std::runtime_error ("Invalid size in
+/// LocalDiscreteConfigDoFValues...") if size does not match _n_sublat *
+/// _n_vol
+void LocalDiscreteConfigDoFValues::set_values(
+    Eigen::Ref<ValueType const> const &_values) {
+  _throw_if_invalid_size(_values);
+  m_vals = _values;
+}
+
+/// Set occupation values to zero
+void LocalDiscreteConfigDoFValues::setZero() { m_vals.setZero(); }
+
+/// Const access occupation values (values are indices into
+/// Site::occupant_dof())
+Eigen::VectorXi const &LocalDiscreteConfigDoFValues::values() const {
+  return m_vals;
+}
+
+/// Access vector block of values for all sites on one sublattice
+LocalDiscreteConfigDoFValues::SublatReference
+LocalDiscreteConfigDoFValues::sublat(Index b) {
+  return m_vals.segment(b * n_vol(), n_vol());
+}
+
+/// Const access vector block of values for all sites on one sublattice
+LocalDiscreteConfigDoFValues::ConstSublatReference
+LocalDiscreteConfigDoFValues::sublat(Index b) const {
+  return m_vals.segment(b * n_vol(), n_vol());
+}
+
+/// Provides the symmetry representations for transforming `values` (i.e. due
+/// to molecule orientation, not for permuting sites)
+std::vector<SymGroupRepID> const &LocalDiscreteConfigDoFValues::symrep_IDs()
+    const {
+  return m_symrep_IDs;
+}
+
+void LocalDiscreteConfigDoFValues::_throw_if_invalid_size(
+    Eigen::Ref<ValueType const> const &_values) const {
+  if (_values.size() != n_vol() * n_sublat()) {
+    std::stringstream msg;
+    msg << "Invalid size in LocalDiscreteConfigDoFValues: "
+        << "Expected size=" << n_vol() * n_sublat()
+        << ", received size=" << _values.size();
+    throw std::runtime_error(msg.str());
+  }
+}
+
+/// local continuous DoF values matrix has #rows == max( DoFSetInfo::dim() )
+Index LocalContinuousConfigDoFValues::matrix_dim(
+    std::vector<DoFSetInfo> const &_info) {
+  Index dim = 0;
+  for (auto const &_dof_set_info : _info) {
+    dim = max(dim, _dof_set_info.dim());
+  }
+  return dim;
+}
+
+LocalContinuousConfigDoFValues::LocalContinuousConfigDoFValues(
+    DoF::BasicTraits const &_traits, Index _n_sublat, Index _n_vol,
+    std::vector<DoFSetInfo> const &_info)
+    : ConfigDoFValues(_traits, _n_sublat, _n_vol),
+      m_dim(matrix_dim(_info)),
+      m_info(_info),
+      m_vals(Eigen::MatrixXd::Zero(m_dim, _n_sublat * _n_vol)) {
+  _throw_if_invalid_size(m_vals);
+}
+
+/// maximum DoF vector representation size (max of DoFSetInfo::dim())
+Index LocalContinuousConfigDoFValues::dim() const { return m_dim; }
+
+/// Access site DoF values (prim DoF basis, matrix representing all sites)
+///
+/// Notes:
+/// - Matrix of size:
+///   - rows=dim() (the max, over all sublattices, prim DoF basis dimension)
+///   - cols=n_vol()*n_sublat()
+/// - Each column represents a site DoF value in the prim DoF basis
+/// - The prim DoF basis can be accessed by `this->info()[b].basis()`, where
+///   `b` is the sublattice index, `b = column_index / this->n_vol()`
+/// - If the prim DoF basis dimension (this->info()[b].basis().cols()) is less
+///   than the standard DoF basis dimension, the matrix includes blocks of
+///   zeros for the corresponding sublattice.
+///
+/// \throws std::runtime_error ("Invalid size in
+/// LocalContinuousConfigDoFValues...") if size is not valid
+void LocalContinuousConfigDoFValues::set_values(
+    Eigen::Ref<const ValueType> const &_values) {
+  _throw_if_invalid_size(_values);
+  m_vals = _values;
+}
+
+/// Set DoF values to zero
+void LocalContinuousConfigDoFValues::setZero() { m_vals.setZero(); }
+
+/// Const access DoF values (prim DoF basis, matrix representing all sites)
+///
+/// Notes:
+/// - Matrix of size rows=dim(), cols=n_vol()*n_sublat(),
+///   - In case the site basis dimension varies from site to site (for
+///     example, displacements are restricted to a 2d plane on some sites,
+///     but not others), the value of dim() is the maximum site basis
+///     dimension for this DoF. The columns corresponding to sublattices with
+///     a smaller basis dimension than dim() have a tail of zeros which should
+///     not be modified.
+/// - Each column represents a site DoF value in the prim DoF basis
+/// - The prim DoF basis can be accessed by `this->info()[b]`, where `b` is
+///   the sublattice index, `b = column_index / this->n_vol()`
+///
+Eigen::MatrixXd const &LocalContinuousConfigDoFValues::values() const {
+  return m_vals;
+}
+
+/// Set local DoF values from standard DoF values
+///
+/// Notes:
+/// - Standard DoF values are those expressed according to the standard DoF
+///   basis, i.e. coordinates whose values corrspond to
+///   AnisoValTraits::standard_var_names().
 void LocalContinuousConfigDoFValues::from_standard_values(
     Eigen::Ref<const Eigen::MatrixXd> const &_standard_values) {
-  resize_vol(_standard_values.cols() / n_sublat());
+  if (_standard_values.rows() != info().front().basis().rows() ||
+      _standard_values.cols() != n_vol() * n_sublat()) {
+    std::stringstream msg;
+    msg << "Invalid standard values input size in "
+           "LocalContinuousConfigDoFValues: "
+        << "Expected rows=" << info().front().basis().rows()
+        << ", received rows=" << _standard_values.rows()
+        << ", expected cols=" << n_vol() * n_sublat()
+        << ", received cols=" << _standard_values.cols();
+    throw std::runtime_error(msg.str());
+  }
   for (Index b = 0; b < n_sublat(); ++b)
     sublat(b).topRows(info()[b].dim()) =
         info()[b].inv_basis() *
         _standard_values.block(0, b * n_vol(), m_vals.rows(), n_vol());
 }
 
+/// Get local DoF values as standard DoF values
+///
+/// Notes:
+/// - Standard DoF values are those expressed according to the standard DoF
+///   basis, i.e. coordinates whose values corrspond to
+///   AnisoValTraits::standard_var_names().
+Eigen::MatrixXd LocalContinuousConfigDoFValues::standard_values() const {
+  Index rows = m_info.front().basis().rows();
+  Eigen::MatrixXd result(rows, m_vals.cols());
+  for (Index b = 0; b < n_sublat(); ++b) {
+    result.block(0, b * n_vol(), rows, n_vol()) =
+        info()[b].basis() * sublat(b).topRows(info()[b].dim());
+  }
+  return result;
+}
+
+/// Access site DoF value vector
+///
+/// Note:
+/// - This is the vector of DoF values associated with a single site, in the
+///   prim DoF basis
+/// - If the prim DoF basis dimension for this site is less than dim(), this
+///   includes a tail of zeros (for rows >= this->info()[b].dim(), where b is
+///   the sublattice index for site_index l). The tail of zeros should not be
+///   modified.
+LocalContinuousConfigDoFValues::SiteReference
+LocalContinuousConfigDoFValues::site_value(Index l) {
+  return m_vals.col(l);
+}
+
+/// Const access site DoF value vector
+///
+/// Note:
+/// - This is the vector of DoF values associated with a single site, in the
+///   prim DoF basis
+/// - If the prim DoF basis dimension for this site is less than dim(), this
+///   includes a tail of zeros (for rows >= this->info()[b].dim(), where b is
+///   the sublattice index for site_index l). The tail of zeros should not be
+///   modified.
+LocalContinuousConfigDoFValues::ConstSiteReference
+LocalContinuousConfigDoFValues::site_value(Index l) const {
+  return m_vals.col(l);
+}
+
+/// Access matrix block of values for all sites on one sublattice
+LocalContinuousConfigDoFValues::SublatReference
+LocalContinuousConfigDoFValues::sublat(Index b) {
+  return m_vals.block(0, b * n_vol(), m_vals.rows(), n_vol());
+}
+
+/// Const access matrix block of values for all sites on one sublattice
+LocalContinuousConfigDoFValues::ConstSublatReference
+LocalContinuousConfigDoFValues::sublat(Index b) const {
+  return m_vals.block(0, b * n_vol(), m_vals.rows(), n_vol());
+}
+
+/// DoFSetInfo provides the basis and symmetry representations for `values`
+std::vector<DoFSetInfo> const &LocalContinuousConfigDoFValues::info() const {
+  return m_info;
+}
+
+void LocalContinuousConfigDoFValues::_throw_if_invalid_size(
+    Eigen::Ref<ValueType const> const &_values) const {
+  if (_values.rows() != dim() || _values.cols() != n_vol() * n_sublat()) {
+    std::stringstream msg;
+    msg << "Invalid size in LocalContinuousConfigDoFValues: "
+        << "Expected rows=" << dim() << ", received rows=" << _values.rows()
+        << ", expected cols=" << n_vol() * n_sublat()
+        << ", received cols=" << _values.cols();
+    throw std::runtime_error(msg.str());
+  }
+}
+
+GlobalContinuousConfigDoFValues::GlobalContinuousConfigDoFValues(
+    DoF::BasicTraits const &_traits, Index _n_sublat, Index _n_vol,
+    DoFSetInfo const &_info)
+    : ConfigDoFValues(_traits, _n_sublat, _n_vol),
+      m_info(_info),
+      m_vals(Eigen::VectorXd::Zero(m_info.dim())) {
+  _throw_if_invalid_size(m_vals);
+}
+
+/// Global DoF vector representation dimension
+Index GlobalContinuousConfigDoFValues::dim() const { return m_vals.rows(); }
+
+/// Set global DoF values
+///
+/// \throws std::runtime_error ("Invalid size in
+/// GlobalContinuousConfigDoFValues...") if size is not valid
+void GlobalContinuousConfigDoFValues::set_values(
+    Eigen::Ref<const Eigen::MatrixXd> const &_values) {
+  _throw_if_invalid_size(_values);
+  m_vals = _values;
+}
+
+/// Set DoF values to zero
+void GlobalContinuousConfigDoFValues::setZero() { m_vals.setZero(); }
+
+/// Const access global DoF values
+Eigen::VectorXd const &GlobalContinuousConfigDoFValues::values() const {
+  return m_vals;
+}
+
+/// Set global DoF values from standard DoF values
+///
+/// Notes:
+/// - Standard DoF values are those expressed according to the standard DoF
+///   basis, i.e. coordinates whose values corrspond to
+///   AnisoValTraits::standard_var_names().
 void GlobalContinuousConfigDoFValues::from_standard_values(
     Eigen::Ref<const Eigen::MatrixXd> const &_standard_values) {
-  values() = info().inv_basis() * _standard_values;
+  if (_standard_values.size() != m_info.basis().rows()) {
+    std::stringstream msg;
+    msg << "Invalid standard values input size in "
+           "GlobalContinuousConfigDoFValues: "
+        << "Expected size=" << m_info.basis().rows()
+        << ", received size=" << _standard_values.size();
+    throw std::runtime_error(msg.str());
+  }
+  m_vals = info().inv_basis() * _standard_values;
+}
+
+/// Get global DoF values as standard DoF values
+///
+/// Notes:
+/// - Standard DoF values are those expressed according to the standard DoF
+/// basis, i.e.
+///   coordinates whose values corrspond to
+///   AnisoValTraits::standard_var_names().
+Eigen::MatrixXd GlobalContinuousConfigDoFValues::standard_values() const {
+  return m_info.basis() * m_vals;
+}
+
+/// DoFSetInfo provides the basis and symmetry representations for `values`
+DoFSetInfo const &GlobalContinuousConfigDoFValues::info() const {
+  return m_info;
+}
+
+void GlobalContinuousConfigDoFValues::_throw_if_invalid_size(
+    Eigen::Ref<ValueType const> const &_values) const {
+  if (_values.size() != m_info.basis().cols()) {
+    std::stringstream msg;
+    msg << "Invalid size in LocalContinuousConfigDoFValues: "
+        << "Expected size=" << m_info.basis().cols()
+        << ", received size=" << _values.size();
+    throw std::runtime_error(msg.str());
+  }
 }
 
 }  // namespace CASM

--- a/src/casm/clex/ConfigEnumAllOccupations.cc
+++ b/src/casm/clex/ConfigEnumAllOccupations.cc
@@ -9,7 +9,7 @@ namespace local_impl {
 std::vector<int> max_selected_occupation(
     ConfigEnumInput const &config_enum_input) {
   auto const &supercell = config_enum_input.configuration().supercell();
-  std::vector<int> max_allowed = supercell.max_allowed_occupation();
+  Eigen::VectorXi max_allowed = supercell.max_allowed_occupation();
 
   std::vector<int> max_allowed_on_selected_sites;
   for (Index i : config_enum_input.sites()) {

--- a/src/casm/clex/ConfigMapping.cc
+++ b/src/casm/clex/ConfigMapping.cc
@@ -7,6 +7,7 @@
 #include "casm/basis_set/DoFTraits.hh"
 #include "casm/casm_io/container/json_io.hh"
 #include "casm/casm_io/dataformatter/DataStream.hh"
+#include "casm/clex/ConfigDoFTools.hh"
 #include "casm/clex/ConfigIsEquivalent.hh"
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/ParamComposition.hh"
@@ -259,8 +260,8 @@ MappingNode copy_apply(PermuteIterator const &_it, MappingNode const &_node,
 std::pair<ConfigDoF, std::set<std::string> > to_configdof(
     SimpleStructure const &_child_struc, Supercell const &_scel) {
   SimpleStructure::Info const &c_info(_child_struc.mol_info);
-  std::pair<ConfigDoF, std::set<std::string> > result(_scel.zero_configdof(TOL),
-                                                      {});
+  std::pair<ConfigDoF, std::set<std::string> > result(
+      make_configdof(_scel, TOL), {});
   PrimClex::PrimType const &prim(_scel.prim());
   Index i = 0;
   for (Index b = 0; b < prim.basis().size(); ++b) {
@@ -467,7 +468,7 @@ ConfigMapperResult ConfigMapper::import_structure(
         struc_mapper().calculator().resolve_setting(map, child_struc);
     std::pair<ConfigDoF, std::set<std::string> > tdof =
         to_configdof(resolved_struc, *shared_scel);
-    Configuration tconfig(shared_scel, jsonParser(), tdof.first);
+    Configuration tconfig(shared_scel, tdof.first);
     PermuteIterator perm_it = shared_scel->sym_info().permute_begin();
     if (settings().strict) {
       // Strictness transformation reduces permutation swaps, translation

--- a/src/casm/clex/PrimClex.cc
+++ b/src/casm/clex/PrimClex.cc
@@ -540,7 +540,7 @@ Clexulator make_clexulator(ProjectSettings const &settings,
   return Clexulator{settings.project_name() + "_Clexulator",
                     settings.dir().clexulator_dir(basis_set_name),
                     prim_neighbor_list, settings.compile_options(),
-                    settings.so_options()};
+                    settings.so_options() + " -lcasm "};
 }
 
 }  // namespace CASM

--- a/src/casm/clex/SuperConfigEnum.cc
+++ b/src/casm/clex/SuperConfigEnum.cc
@@ -3,6 +3,7 @@
 #include "casm/app/casm_functions.hh"
 #include "casm/app/enum.hh"
 #include "casm/app/io/json_io_impl.hh"
+#include "casm/clex/ConfigDoFTools.hh"
 #include "casm/clex/ConfigEnumByPermutation.hh"
 #include "casm/clex/FillSupercell.hh"
 #include "casm/clex/FilteredConfigIterator.hh"
@@ -111,7 +112,7 @@ bool SuperConfigEnum::_check_current() const { return true; }
 void SuperConfigEnum::_fill(Array<int> const &counter_val,
                             Configuration &super_config) {
   double xtal_tol = super_config.supercell().prim().lattice().tol();
-  super_config.configdof() = super_config.supercell().zero_configdof(xtal_tol);
+  super_config.configdof() = make_configdof(super_config.supercell(), xtal_tol);
 
   for (Index i = 0; i < this->_unitcell_index_converter().total_sites(); ++i) {
     Configuration const &sub_config_i = _sub_config()[counter_val[i]];
@@ -121,11 +122,11 @@ void SuperConfigEnum::_fill(Array<int> const &counter_val,
 
       for (auto &pair : super_config.configdof().local_dofs()) {
         auto const &dof_key = pair.first;
-        auto &local_dof_values =
-            super_config.configdof().local_dof(dof_key).values();
 
-        local_dof_values.col(m_index_map[i][j]) =
-            sub_config_i.configdof().local_dof(dof_key).values().col(j);
+        auto &local_dof = super_config.configdof().local_dof(dof_key);
+
+        local_dof.site_value(m_index_map[i][j]) =
+            sub_config_i.configdof().local_dof(dof_key).site_value(j);
       }
     }
   }

--- a/src/casm/clex/io/json/Configuration_json_io.cc
+++ b/src/casm/clex/io/json/Configuration_json_io.cc
@@ -38,7 +38,7 @@ std::unique_ptr<Configuration> jsonMake<Configuration>::make_from_json(
   report_and_throw_if_invalid(parser, log, error_if_invalid);
   auto shared_supercell = std::make_shared<Supercell const>(shared_prim, T);
 
-  ConfigDoF configdof = make_configdof(*shared_prim, T.determinant());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
   parser.optional(configdof, "dof");
 
   if (configdof.n_vol() != shared_supercell->volume()) {
@@ -102,23 +102,20 @@ jsonParser &to_json(Configuration const &configuration, jsonParser &json) {
 ///
 /// Note:
 /// - See `to_json(Configuration const &configuration, jsonParser &json)` for
-/// expected format.
+///   expected format.
 /// - The attribute "transformation_matrix_to_super" must be present. If
-/// "supercell_name" is
-///   present it is ignored.
+///   "supercell_name" is present it is ignored.
 /// - The constructed Configuration is not necessarily canonical, nor is its
-/// Supercell.
+///   Supercell.
 /// - The constructed Configuration has a shared Supercell
-/// (`std::shared_ptr<Supercell const>`)
-///   that is not owned by any Supercell database.
+///   (`std::shared_ptr<Supercell const>`) that is not owned by any Supercell
+///   database.
 /// - Use `DB::in_canonical_supercell` to make the canonical equivalent
-/// configuration with the
-///   canonical supercell from the Supercell database, without inserting the
-///   configuration in the Configuration database.
+///   configuration with the canonical supercell from the Supercell database,
+///   without inserting the configuration in the Configuration database.
 /// - Use `DB::make_canonical_and_insert` to make the equivalent configuration
-/// with the canonical
-///   supercell from the Supercell database and insert the canonical equivalent
-///   configuration in the Configuration database.
+///   with the canonical supercell from the Supercell database and insert the
+///   canonical equivalent configuration in the Configuration database.
 ///
 void from_json(Configuration &configuration, jsonParser const &json) {
   configuration = jsonConstructor<Configuration>::from_json(

--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -234,9 +234,9 @@ void set_dof_value(Configuration &config, DoFSpace const &dof_space,
       throw std::runtime_error(msg.str());
     }
 
+    auto &local_dof = config.configdof().local_dof(dof_key);
     Eigen::VectorXd vector_values = basis * normal_coordinate;
-    Eigen::MatrixXd &matrix_values =
-        config.configdof().local_dof(dof_key).values();
+    Eigen::MatrixXd matrix_values = local_dof.values();
 
     auto const &axis_dof_component = dof_space.axis_dof_component().value();
     auto const &axis_site_index = dof_space.axis_site_index().value();
@@ -245,6 +245,8 @@ void set_dof_value(Configuration &config, DoFSpace const &dof_space,
       matrix_values(axis_dof_component[i], axis_site_index[i]) =
           vector_values[i];
     }
+
+    local_dof.set_values(matrix_values);
   }
 }
 

--- a/src/casm/monte_carlo/MonteIO.cc
+++ b/src/casm/monte_carlo/MonteIO.cc
@@ -432,8 +432,9 @@ void write_POSCAR_initial(const MonteCarlo &mc, size_type cond_index,
   fs::create_directories(dir.trajectory_dir(cond_index));
 
   // read initial_state.json
-  ConfigDoF config_dof = jsonParser(dir.initial_state_json(cond_index))
-                             .get<ConfigDoF>(mc.primclex().prim());
+  ConfigDoF config_dof =
+      jsonParser(dir.initial_state_json(cond_index))
+          .get<ConfigDoF>(mc.supercell().prim(), mc.supercell().volume());
 
   if (!fs::exists(dir.initial_state_json(cond_index))) {
     throw std::runtime_error(
@@ -459,8 +460,9 @@ void write_POSCAR_final(const MonteCarlo &mc, size_type cond_index, Log &_log) {
   fs::create_directories(dir.trajectory_dir(cond_index));
 
   // read final_state.json
-  ConfigDoF config_dof = jsonParser(dir.final_state_json(cond_index))
-                             .get<ConfigDoF>(mc.primclex().prim());
+  ConfigDoF config_dof =
+      jsonParser(dir.final_state_json(cond_index))
+          .get<ConfigDoF>(mc.supercell().prim(), mc.supercell().volume());
 
   if (!fs::exists(dir.final_state_json(cond_index))) {
     throw std::runtime_error(
@@ -491,8 +493,6 @@ void write_POSCAR_trajectory(const MonteCarlo &mc, size_type cond_index,
   std::vector<size_type> step;
   std::vector<ConfigDoF> trajectory;
 
-  Structure const &primstruc = mc.supercell().prim();
-
   if (mc.settings().write_json()) {
     std::string filename = dir.trajectory_json(cond_index).string() + ".gz";
 
@@ -512,7 +512,8 @@ void write_POSCAR_trajectory(const MonteCarlo &mc, size_type cond_index,
       step.push_back(it->get<size_type>());
     }
     for (auto it = json["DoF"].cbegin(); it != json["DoF"].cend(); ++it) {
-      trajectory.push_back(it->get<ConfigDoF>(primstruc));
+      trajectory.push_back(
+          it->get<ConfigDoF>(mc.supercell().prim(), mc.supercell().volume()));
     }
 
   } else if (mc.settings().write_csv()) {

--- a/src/casm/monte_carlo/MonteSettings.cc
+++ b/src/casm/monte_carlo/MonteSettings.cc
@@ -82,13 +82,14 @@ bool MonteSettings::is_motif_configdof() const {
 }
 
 /// \brief ConfigDoF to use as starting motif
-ConfigDoF MonteSettings::motif_configdof() const {
+ConfigDoF MonteSettings::motif_configdof(Index supercell_volume) const {
   std::string help =
       "string\n"
       "  Path to file containing DoF, such as an \"final_state.json\" file.";
   fs::path configdof_path =
       _get_setting<fs::path>("driver", "motif", "configdof", help);
-  return jsonParser(configdof_path).get<ConfigDoF>(primclex().prim());
+  return jsonParser(configdof_path)
+      .get<ConfigDoF>(primclex().prim(), supercell_volume);
 }
 
 /// \brief Path to ConfigDoF file to use as starting motif

--- a/src/casm/monte_carlo/canonical/Canonical.cc
+++ b/src/casm/monte_carlo/canonical/Canonical.cc
@@ -149,7 +149,7 @@ std::pair<ConfigDoF, std::string> Canonical::set_state(
     _log() << "motif configdof: " << settings.motif_configdof_path() << "\n";
     _log() << "using configdof: " << settings.motif_configdof_path() << "\n"
            << std::endl;
-    configdof = settings.motif_configdof();
+    configdof = settings.motif_configdof(supercell().volume());
     configname = settings.motif_configdof_path().string();
   } else {
     throw std::runtime_error(
@@ -556,7 +556,7 @@ std::vector<OccSwap>::const_iterator Canonical::_find_grand_canonical_swap(
 ///
 ConfigDoF Canonical::_enforce_conditions(const ConfigDoF &configdof) {
   _log().custom("Enforce composition");
-  Configuration tconfig(_supercell(), jsonParser(), configdof);
+  Configuration tconfig(_supercell(), configdof);
   m_occ_loc.initialize(tconfig);
   jsonParser json;
 

--- a/src/casm/monte_carlo/grand_canonical/GrandCanonical.cc
+++ b/src/casm/monte_carlo/grand_canonical/GrandCanonical.cc
@@ -155,7 +155,7 @@ std::pair<ConfigDoF, std::string> GrandCanonical::set_state(
     _log() << "motif configdof: " << settings.motif_configdof_path() << "\n";
     _log() << "using configdof: " << settings.motif_configdof_path() << "\n"
            << std::endl;
-    configdof = settings.motif_configdof();
+    configdof = settings.motif_configdof(supercell().volume());
     configname = settings.motif_configdof_path().string();
   } else {
     throw std::runtime_error(

--- a/src/casm/system/RuntimeLibrary.cc
+++ b/src/casm/system/RuntimeLibrary.cc
@@ -139,6 +139,7 @@ void RuntimeLibrary::_close() {
   // close
   if (m_handle != nullptr) {
     dlclose(m_handle);
+    m_handle = nullptr;
   }
 }
 
@@ -158,9 +159,7 @@ std::vector<std::string> _cxx_env() {
 }
 
 std::vector<std::string> _cxxflags_env() {
-  return std::vector<std::string>{
-      "CASM_CXXFLAGS",
-  };
+  return std::vector<std::string>{"CASM_CXXFLAGS"};
 }
 
 std::vector<std::string> _soflags_env() {

--- a/tests/unit/App/TestEnum.cc
+++ b/tests/unit/App/TestEnum.cc
@@ -86,7 +86,7 @@ namespace local_impl {
 std::vector<int> max_selected_occupation(
     ConfigEnumInput const &config_enum_input) {
   auto const &supercell = config_enum_input.configuration().supercell();
-  std::vector<int> max_allowed = supercell.max_allowed_occupation();
+  Eigen::VectorXi max_allowed = supercell.max_allowed_occupation();
 
   std::vector<int> max_allowed_on_selected_sites;
   for (Index i : config_enum_input.sites()) {
@@ -94,6 +94,15 @@ std::vector<int> max_selected_occupation(
   }
 
   return max_allowed_on_selected_sites;
+}
+
+void set_occupation(Configuration &configuration,
+                    std::set<Index> const &site_indices,
+                    std::vector<int> const &counter) {
+  Index i = 0;
+  for (Index site_index : site_indices) {
+    configuration.set_occ(site_index, counter[i++]);
+  }
 }
 }  // namespace local_impl
 
@@ -114,7 +123,7 @@ TestEnum::TestEnum(const ConfigEnumInput &config_enum_input)
       m_enumerate_on_a_subset_of_supercell_sites(
           m_site_index_selection.size() !=
           config_enum_input.configuration().size()) {
-  m_current->set_occupation(m_counter());
+  local_impl::set_occupation(*m_current, m_site_index_selection, m_counter);
   reset_properties(*m_current);
   this->_initialize(&(*m_current));
 

--- a/tests/unit/Common.hh
+++ b/tests/unit/Common.hh
@@ -6,6 +6,7 @@
 
 #include "casm/casm_io/Log.hh"
 #include "casm/casm_io/json/jsonParser.hh"
+#include "casm/global/eigen.hh"
 // #include "FCCTernaryProj.hh"
 // #include "ZrOProj.hh"
 
@@ -35,6 +36,17 @@ void print_computed_result(std::ostream &sout, std::string name,
     }
   }
   sout << "};" << std::endl;
+}
+
+template <typename T>
+Eigen::Matrix<T, Eigen::Dynamic, 1> eigen_vector(std::initializer_list<T> v) {
+  Eigen::Matrix<T, Eigen::Dynamic, 1> eigen_v =
+      Eigen::Matrix<T, Eigen::Dynamic, 1>::Zero(v.size());
+  int i = 0;
+  for (int value : v) {
+    eigen_v[i++] = value;
+  }
+  return eigen_v;
 }
 
 }  // namespace test

--- a/tests/unit/TestConfiguration.cc
+++ b/tests/unit/TestConfiguration.cc
@@ -1,5 +1,6 @@
 #include "TestConfiguration.hh"
 
+#include "Common.hh"
 #include "casm/casm_io/json/jsonParser.hh"
 #include "casm/clex/FillSupercell.hh"
 
@@ -11,14 +12,14 @@ TestConfiguration::TestConfiguration(const PrimClex &primclex,
 
 TestConfiguration::TestConfiguration(const PrimClex &primclex,
                                      const Eigen::Matrix3l &T,
-                                     const std::vector<int> &_occupation)
+                                     Eigen::VectorXi const &_occupation)
     : TestConfiguration(primclex,
                         xtal::make_superlattice(primclex.prim().lattice(), T),
                         _occupation) {}
 
 TestConfiguration::TestConfiguration(const PrimClex &primclex,
                                      const Lattice &lat,
-                                     const std::vector<int> &_occupation)
+                                     Eigen::VectorXi const &_occupation)
     : TestSupercell(primclex, lat), config(Configuration::zeros(this->scel)) {
   config.set_occupation(_occupation);
 }

--- a/tests/unit/TestConfiguration.hh
+++ b/tests/unit/TestConfiguration.hh
@@ -11,10 +11,10 @@ struct TestConfiguration : public test::TestSupercell {
   TestConfiguration(const PrimClex &primclex, const Configuration &_config);
 
   TestConfiguration(const PrimClex &primclex, const Eigen::Matrix3l &T,
-                    const std::vector<int> &_occupation);
+                    Eigen::VectorXi const &_occupation);
 
   TestConfiguration(const PrimClex &primclex, const Lattice &lat,
-                    const std::vector<int> &_occupation);
+                    Eigen::VectorXi const &_occupation);
 
   TestConfiguration(const PrimClex &primclex, const Configuration &unit,
                     const Eigen::Matrix3l &T, double tol = TOL);

--- a/tests/unit/clex/ConfigDoF_test.cpp
+++ b/tests/unit/clex/ConfigDoF_test.cpp
@@ -1,5 +1,6 @@
 #include "casm/clex/ConfigDoF.hh"
 
+#include "casm/clex/ConfigDoFTools.hh"
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/Supercell.hh"
 #include "casm/crystallography/Structure.hh"
@@ -25,8 +26,7 @@ TEST(ConfigDoFTest, Constructor0) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(
       configdof.has_occupation(),
@@ -43,8 +43,7 @@ TEST(ConfigDoFTest, Constructor1) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(configdof.has_occupation(), true);
   EXPECT_EQ(configdof.occupation(),
@@ -61,8 +60,7 @@ TEST(ConfigDoFTest, Constructor2) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(configdof.has_occupation(), true);
   EXPECT_EQ(configdof.global_dofs().size(), 1);
@@ -78,8 +76,7 @@ TEST(ConfigDoFTest, Constructor3) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(configdof.has_occupation(), true);
   EXPECT_EQ(configdof.global_dofs().size(), 1);
@@ -95,8 +92,7 @@ TEST(ConfigDoFTest, Constructor4) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(configdof.has_occupation(), true);
   EXPECT_EQ(configdof.global_dofs().size(), 0);
@@ -113,8 +109,7 @@ TEST(ConfigDoFTest, Constructor5) {
   auto shared_supercell = std::make_shared<Supercell const>(
       shared_prim, Eigen::Matrix3l::Identity());
 
-  ConfigDoF configdof =
-      shared_supercell->zero_configdof(shared_prim->lattice().tol());
+  ConfigDoF configdof = make_configdof(*shared_supercell);
 
   EXPECT_EQ(configdof.has_occupation(), true);
   EXPECT_EQ(configdof.global_dofs().size(), 1);

--- a/tests/unit/clex/Configuration_test.cpp
+++ b/tests/unit/clex/Configuration_test.cpp
@@ -80,7 +80,7 @@ TEST(ConfigurationTest, Test1) {
   config.init_occupation();
   EXPECT_EQ(config.has_occupation(), true);
 
-  config.set_occupation(std::vector<int>({0}));
+  config.set_occupation(test::eigen_vector<int>({0}));
   EXPECT_EQ(config.has_occupation(), true);
 
   for (int i = 0; i < 3; ++i) {
@@ -105,7 +105,7 @@ TEST(ConfigurationTest, Test2) {
   EXPECT_EQ(config.size(), 2);
 
   // include occupation only
-  config.set_occupation(std::vector<int>({1, 0}));
+  config.set_occupation(test::eigen_vector<int>({1, 0}));
 
   {
     // Identity op
@@ -114,7 +114,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[0], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0}));
 
     EXPECT_EQ(filled, check);
   }
@@ -126,7 +126,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[0], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0, 1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0, 1, 0}));
 
     EXPECT_EQ(filled, check);
   }
@@ -139,7 +139,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[1], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0}));
 
     EXPECT_EQ(filled, check);
   }
@@ -159,7 +159,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[0], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0}));
     // check.set_disp(0, dx);
 
     EXPECT_EQ(filled, check);
@@ -172,7 +172,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[0], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0, 1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0, 1, 0}));
     // check.init_displacement();
     // check.set_disp(0, dx);
     // check.set_disp(2, dx);
@@ -187,7 +187,7 @@ TEST(ConfigurationTest, Test2) {
     Configuration filled = fill_supercell(fg[1], config, scel);
 
     Configuration check(scel);
-    check.set_occupation(std::vector<int>({1, 0}));
+    check.set_occupation(test::eigen_vector<int>({1, 0}));
     // check.init_displacement();
     // check.set_disp(0, dy);
 
@@ -214,14 +214,14 @@ TEST(ConfigurationTest, Test3) {
 
     {
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({1, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({1, 0, 0, 0}));
       EXPECT_EQ(config.is_canonical(), true);
       EXPECT_EQ(config.is_primitive(), true);
       EXPECT_EQ(config.invariant_subgroup().size(), 48);
 
       {
         Configuration test(scel);
-        test.set_occupation(std::vector<int>({1, 0, 0, 0}));
+        test.set_occupation(test::eigen_vector<int>({1, 0, 0, 0}));
         EXPECT_EQ(config == test, true);
         EXPECT_EQ(config.is_sym_equivalent(test), true);
         EXPECT_EQ(test.is_sym_equivalent(config), true);
@@ -231,7 +231,7 @@ TEST(ConfigurationTest, Test3) {
 
       {
         Configuration test(scel);
-        test.set_occupation(std::vector<int>({0, 1, 0, 0}));
+        test.set_occupation(test::eigen_vector<int>({0, 1, 0, 0}));
         EXPECT_EQ(config == test, false);
         EXPECT_EQ(config.is_sym_equivalent(test), true);
         EXPECT_EQ(test.is_sym_equivalent(config), true);
@@ -265,7 +265,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0}));
+      config.set_occupation(test::eigen_vector<int>({0}));
 
       // not in datbase -> id == "none"
       EXPECT_EQ(config.name(), "SCEL1_1_1_1_0_0_0/none");
@@ -284,7 +284,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({1}));
+      config.set_occupation(test::eigen_vector<int>({1}));
       // not in datbase -> id == "none"
       EXPECT_EQ(config.name(), "SCEL1_1_1_1_0_0_0/none");
 
@@ -302,7 +302,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0}));
+      config.set_occupation(test::eigen_vector<int>({0}));
 
       // not from database, but now in it -> id == "0"
       EXPECT_EQ(config.name(), "SCEL1_1_1_1_0_0_0/0");
@@ -320,7 +320,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({1, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({1, 0, 0, 0}));
       EXPECT_EQ(config.name(), "SCEL4_2_2_1_1_1_0/none");
 
       auto res = db.insert(config.in_canonical_supercell());
@@ -333,7 +333,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, non-canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 1, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 1, 0, 0}));
 
       EXPECT_EQ(config.name(), "SCEL4_2_2_1_1_1_0/0.equiv.0.1");
 
@@ -350,7 +350,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // canonical scel, canonical non-primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 0, 0, 0}));
 
       EXPECT_EQ(config.name(), "SCEL4_2_2_1_1_1_0/none");
 
@@ -388,7 +388,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // non-canonical scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({1, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({1, 0, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above
@@ -405,7 +405,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // non-canonical scel, non-canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 1, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 1, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above
@@ -424,7 +424,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // equivalent, but non-canonical scel, canonical non-primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 0, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above
@@ -445,7 +445,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // non-canonical, non-equivalent, scel, canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({1, 0, 0, 0, 0, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({1, 0, 0, 0, 0, 0, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above
@@ -465,7 +465,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // non-canonical, non-equivalent, scel, non-canonical primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 1, 0, 0, 0, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 1, 0, 0, 0, 0, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above
@@ -486,7 +486,7 @@ TEST(ConfigurationTest, TestConfigurationName) {
     {
       // non-canonical, non-equivalent, scel, canonical non-primitive occ
       Configuration config(scel);
-      config.set_occupation(std::vector<int>({0, 0, 0, 0, 0, 0, 0, 0}));
+      config.set_occupation(test::eigen_vector<int>({0, 0, 0, 0, 0, 0, 0, 0}));
 
       // having a different, but equivalent supercell, should not change name ^
       // see above

--- a/tests/unit/clex/SuperConfigEnum_test.cpp
+++ b/tests/unit/clex/SuperConfigEnum_test.cpp
@@ -33,7 +33,7 @@ TEST(SuperConfigEnumTest, Test1) {
 
   auto sub_config = [&](std::initializer_list<int> occ) {
     Configuration tconfig(motif_scel);
-    tconfig.set_occupation(std::vector<int>(occ));
+    tconfig.set_occupation(test::eigen_vector<int>(occ));
     return tconfig;
   };
 

--- a/tests/unit/database/jsonConfigDatabase_test.cpp
+++ b/tests/unit/database/jsonConfigDatabase_test.cpp
@@ -42,7 +42,7 @@ TEST(jsonConfigDatabase_Test, Test1) {
   const Supercell &scel = *tscel.insert().first;
   double tol = 1e-5;
 
-  Configuration config(scel, jsonParser(), scel.zero_configdof(tol));
+  Configuration config{scel};
 
   // Insert a Configuration
   auto res = db_config.insert(config);
@@ -56,6 +56,11 @@ TEST(jsonConfigDatabase_Test, Test1) {
   // Enumerate and insert Configs
   ConfigEnumAllOccupations enum_config(scel);
   for (const auto &config : enum_config) {
+    /// Use while transitioning Supercell to no longer need a `PrimClex const
+    /// *`
+    if (!config.supercell().has_primclex()) {
+      config.supercell().set_primclex(&primclex);
+    }
     db_config.insert(config);
   }
   db_config.commit();
@@ -102,8 +107,9 @@ TEST(jsonConfigDatabase_Test, Test1) {
 
   // Check cached properties
   for (const auto &config : db_config) {
-    // std::cout << "id: " << config.id() << "  occ: " << config.occupation() <<
-    // std::endl;
+    // std::cout << "id: " << config.id()
+    //   << "  occ: " << config.occupation().transpose() << std::endl;
+    // std::cout << "cache: " << config.cache() << std::endl;
     EXPECT_EQ(config.cache().contains("multiplicity"), true);
   }
 

--- a/tests/unit/examples/200_enumeration_Configuration_test.cpp
+++ b/tests/unit/examples/200_enumeration_Configuration_test.cpp
@@ -119,7 +119,7 @@
 //       ... ]
 //
 // - the values of the continuous global DoF ("global_dofs",
-//   std::map<DoFKey, GlobalDoFContainerType>).
+//   std::map<DoFKey, GlobalContinuousConfigDoFValues>).
 //
 //   Example: GLstrain values, with prim DoF basis equal to the standard basis,
 //   accessed via `Eigen::VectorXd const

--- a/tests/unit/symmetry/Orbit_test.cpp
+++ b/tests/unit/symmetry/Orbit_test.cpp
@@ -24,7 +24,7 @@ namespace {
 struct TestConfig0 : test::TestConfiguration {
   TestConfig0(const PrimClex &primclex)
       : TestConfiguration(primclex, Eigen::Vector3l(2, 1, 1).asDiagonal(),
-                          {0, 0, 0, 0, 1, 1, 0, 0}) {
+                          test::eigen_vector<int>({0, 0, 0, 0, 1, 1, 0, 0})) {
     EXPECT_EQ(this->scel_fg().size(), 16);
     EXPECT_EQ(this->config_sym_fg().size(), 8);
   }

--- a/tests/unit/symmetry/SymBasisPermute_test.cpp
+++ b/tests/unit/symmetry/SymBasisPermute_test.cpp
@@ -18,7 +18,7 @@ namespace {
 struct TestConfig0 : test::TestConfiguration {
   TestConfig0(const PrimClex &primclex)
       : TestConfiguration(primclex, Eigen::Vector3l(2, 1, 1).asDiagonal(),
-                          {0, 0, 0, 0, 1, 1, 0, 0}) {
+                          test::eigen_vector<int>({0, 0, 0, 0, 1, 1, 0, 0})) {
     EXPECT_EQ(this->scel_fg().size(), 16);
     EXPECT_EQ(this->config_sym_fg().size(), 8);
   }


### PR DESCRIPTION
This PR fixes an issue that was causing crashes when reading ConfigDoF from JSON and does some refactoring to make ConfigDoF better documented and easier to use correctly. The main changes are included in the first commit. The other commits handle downstream effects of the changes in the first commit. The changes include:

- Remove options to resize ConfigDoF:
- ConfigDoF and ConfigDoFValues can still be copied, but the underlying vectors and matrices are otherwise fixed at the correct size upon construction. 
- The `values()` non-const reference members in the ConfigDoFValues classes have been changed to `set_values` members and input is always checked for the correct dimension and exceptions thrown if not correct.
- A number of typedefs and using aliases have been removed in favor of using Eigen::VectorXi, Eigen::MatrixXd, and Eigen::VectorXd directly to improve clarity
- Documentation for the ConfigDoFValues classes was fixed, updated and expanded 
- ConfigDoF is always constructed with all zero values. The `make_configdof` methods in "clex/ConfigDoFTools.hh" give the easiest ways to construct ConfigDoF. The `Supercell::zero_configdof` method is removed to reduce dependencies in favor of using `make_configdof`.
- Finished separating JSON IO from the Configuration and ConfigDoF classes
- Improved ConfigDoF JSON IO error messages
- Removed the `jsonParser source` constructor argument from Configuration.
- Testing downstream changes also fixed a couple issues with GCC compilation