### PR TITLE
Enumerate site dofs without homogeneous modes

### DIFF
--- a/include/casm/clex/ConfigEnumSiteDoFs.hh
+++ b/include/casm/clex/ConfigEnumSiteDoFs.hh
@@ -106,10 +106,6 @@ struct ConfigEnumSiteDoFsParams {
   /// Maximum number of number modes included in the linear combination applied
   /// to the initial state
   Index max_nonzero;
-
-  /// A boolean flag which lets you turn on or off homogeneous modes
-  /// They are included by default and this flag should be used to turn them off
-  bool exclude_homogeneous_modes;
 };
 
 /// Enumerate site (continuous local) DoFs
@@ -130,7 +126,7 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
                      Eigen::Ref<const Eigen::VectorXd> const &min_val,
                      Eigen::Ref<const Eigen::VectorXd> const &max_val,
                      Eigen::Ref<const Eigen::VectorXd> const &inc_val,
-                     bool exclude_homogeneous_modes, Index _min_nonzero,
+                     Index _min_nonzero,
                      Index _max_nonzero);
 
   std::string name() const override;
@@ -176,28 +172,12 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
 
   bool m_subset_mode;
 
-  bool m_exclude_homogeneous_modes;
-
   Index m_combo_index;
 
   std::vector<Index> m_combo;
 
   EigenCounter<Eigen::VectorXd> m_counter;
 };
-
-/// Checks if all the dof values at each site are the same
-bool are_all_dof_vals_same(const std::vector<Eigen::VectorXd> &dof_vals);
-
-/// Constructs a homogeneous mode space of the dof space represented in terms of
-/// user defined axes. Returns a column vectors matrix
-Eigen::MatrixXd make_homogeneous_mode_space(
-    const std::vector<DoFSetInfo> &dof_info);
-
-/// Returns true if the homogeneous modes are mixed within two irreps.
-/// This will be used to issue a warning to the user to look at stuff more
-/// carefully
-bool are_homogeneous_modes_mixed_in_irreps(
-    const Eigen::MatrixXd &axes, const Eigen::MatrixXd &homogeneous_mode_space);
 }  // namespace CASM
 
 #endif

--- a/include/casm/clex/ConfigEnumSiteDoFs.hh
+++ b/include/casm/clex/ConfigEnumSiteDoFs.hh
@@ -106,6 +106,10 @@ struct ConfigEnumSiteDoFsParams {
   /// Maximum number of number modes included in the linear combination applied
   /// to the initial state
   Index max_nonzero;
+
+  /// A boolean flag which lets you turn on or off homogeneous modes
+  /// They are included by default and this flag should be used to turn them off
+  bool exclude_homogeneous_modes;
 };
 
 /// Enumerate site (continuous local) DoFs
@@ -126,7 +130,8 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
                      Eigen::Ref<const Eigen::VectorXd> const &min_val,
                      Eigen::Ref<const Eigen::VectorXd> const &max_val,
                      Eigen::Ref<const Eigen::VectorXd> const &inc_val,
-                     Index _min_nonzero, Index _max_nonzero);
+                     bool exclude_homogeneous_modes, Index _min_nonzero,
+                     Index _max_nonzero);
 
   std::string name() const override;
 
@@ -171,6 +176,8 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
 
   bool m_subset_mode;
 
+  bool m_exclude_homogeneous_modes;
+
   Index m_combo_index;
 
   std::vector<Index> m_combo;
@@ -178,6 +185,19 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
   EigenCounter<Eigen::VectorXd> m_counter;
 };
 
+/// Checks if all the dof values at each site are the same
+bool are_all_dof_vals_same(const std::vector<Eigen::VectorXd> &dof_vals);
+
+/// Constructs a homogeneous mode space of the dof space represented in terms of
+/// user defined axes. Returns a column vectors matrix
+Eigen::MatrixXd make_homogeneous_mode_space(
+    const std::vector<DoFSetInfo> &dof_info);
+
+/// Returns true if the homogeneous modes are mixed within two irreps.
+/// This will be used to issue a warning to the user to look at stuff more
+/// carefully
+bool are_homogeneous_modes_mixed_in_irreps(
+    const Eigen::MatrixXd &axes, const Eigen::MatrixXd &homogeneous_mode_space);
 }  // namespace CASM
 
 #endif

--- a/include/casm/clex/ConfigEnumSiteDoFs.hh
+++ b/include/casm/clex/ConfigEnumSiteDoFs.hh
@@ -126,8 +126,7 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
                      Eigen::Ref<const Eigen::VectorXd> const &min_val,
                      Eigen::Ref<const Eigen::VectorXd> const &max_val,
                      Eigen::Ref<const Eigen::VectorXd> const &inc_val,
-                     Index _min_nonzero,
-                     Index _max_nonzero);
+                     Index _min_nonzero, Index _max_nonzero);
 
   std::string name() const override;
 

--- a/include/casm/clex/ConfigEnumSiteDoFs.hh
+++ b/include/casm/clex/ConfigEnumSiteDoFs.hh
@@ -177,6 +177,7 @@ class ConfigEnumSiteDoFs : public InputEnumeratorBase<Configuration> {
 
   EigenCounter<Eigen::VectorXd> m_counter;
 };
+
 }  // namespace CASM
 
 #endif

--- a/include/casm/enumerator/DoFSpace.hh
+++ b/include/casm/enumerator/DoFSpace.hh
@@ -256,7 +256,7 @@ struct VectorSpaceMixingInfo {
 /// The result of this function might be different from just the symmetry
 /// adapted axes computed using irrep decomposition and explicitly removing the
 /// homogeneous modes by identifying them using the
-/// get_indices_of_rigid_translation_space below This is implemented by
+/// VectorSpaceMixingInfo struct. This is implemented by
 /// computing the null space of the homogeneous mode space and using it is a
 /// subspace while performing irrep decomposition
 Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(

--- a/include/casm/enumerator/DoFSpace.hh
+++ b/include/casm/enumerator/DoFSpace.hh
@@ -218,7 +218,8 @@ VectorSpaceSymReport vector_space_sym_report(DoFSpace const &dof_space,
 DoFSpace make_symmetry_adapted_dof_space(
     DoFSpace const &dof_space, ConfigEnumInput const &input_state,
     std::vector<PermuteIterator> const &group, bool calc_wedges,
-    std::optional<VectorSpaceSymReport> &symmetry_report);
+    std::optional<VectorSpaceSymReport> &symmetry_report
+    );
 
 class make_symmetry_adapted_dof_space_error : public std::runtime_error {
  public:
@@ -227,6 +228,24 @@ class make_symmetry_adapted_dof_space_error : public std::runtime_error {
   virtual ~make_symmetry_adapted_dof_space_error() {}
 };
 
+/// Constructs a homogeneous mode space of the dof space represented in terms of
+/// user defined axes. Returns a column vectors matrix
+Eigen::MatrixXd make_homogeneous_mode_space(
+    const std::vector<DoFSetInfo> &dof_info);
+
+/// Returns true if the homogeneous modes are mixed within two irreps.
+/// This will be used to issue a warning to the user to look at stuff more
+/// carefully
+bool are_homogeneous_modes_mixed_in_irreps(
+    const Eigen::MatrixXd &axes, const Eigen::MatrixXd &homogeneous_mode_space);
+
+Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
+    const DoFSpace& symmetry_adapted_dof_space,
+    const ConfigEnumInput& initial_state);
+
+std::vector<int> get_indices_of_rigid_translation_space(
+    const DoFSpace& symmetry_adapted_dof_space,
+    const ConfigEnumInput& initial_state);
 }  // namespace CASM
 
 #endif

--- a/include/casm/enumerator/DoFSpace.hh
+++ b/include/casm/enumerator/DoFSpace.hh
@@ -230,13 +230,27 @@ class make_symmetry_adapted_dof_space_error : public std::runtime_error {
 /// Constructs a homogeneous mode space of the dof space represented in terms of
 /// user defined axes. Returns a column vectors matrix
 Eigen::MatrixXd make_homogeneous_mode_space(
-    const std::vector<DoFSetInfo> &dof_info);
+    std::vector<DoFSetInfo> const &dof_info);
 
-/// Returns true if the homogeneous modes are mixed within two irreps.
-/// This will be used to issue a warning to the user to look at stuff more
-/// carefully
-bool are_homogeneous_modes_mixed_in_irreps(
-    const Eigen::MatrixXd &axes, const Eigen::MatrixXd &homogeneous_mode_space);
+/// A struct which gives out the mixing information of given column_vector_space
+/// and a subspace For example, consider a column_vector_space of 3 dimensions.
+/// Let it be [q1, q2, q3] where q1, q2 and q3 are columns of the said vector
+/// space Let's say q1 - has a zero projection onto the given subspace, q2 - has
+/// partial projection onto the subspace, q3 - full projection onto the subspace
+/// Then axes_not_in_subspace will be {0} - where 0 is the index of the column
+/// of the column_vector_space which has zero projection onto the given subspace
+/// Similarly, axes_in_subspace will be {2} & axes_mixed_with_subspace will be
+/// {1} If any of the columns of the given column_vector_space has a partial
+/// projection onto the subspace, are_axes_mixed_with_subspace will be true;
+/// otherwise it will be false
+struct VectorSpaceMixingInfo {
+  VectorSpaceMixingInfo(Eigen::MatrixXd const &column_vector_space,
+                        Eigen::MatrixXd const &subspace, double tol);
+  std::vector<Index> axes_not_in_subspace;
+  std::vector<Index> axes_in_subspace;
+  std::vector<Index> axes_mixed_with_subspace;
+  bool are_axes_mixed_with_subspace = true;
+};
 
 /// Returns symmetry adapted axes with homogeneous modes removed
 /// The result of this function might be different from just the symmetry
@@ -246,17 +260,9 @@ bool are_homogeneous_modes_mixed_in_irreps(
 /// computing the null space of the homogeneous mode space and using it is a
 /// subspace while performing irrep decomposition
 Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
-    const DoFSpace &symmetry_adapted_dof_space,
-    const ConfigEnumInput &initial_state);
+    DoFSpace const &symmetry_adapted_dof_space,
+    ConfigEnumInput const &initial_state);
 
-/// Returns the column numbers of the symmetry adapted axes which are
-/// homogeneous modes This assumes that the provided symmetry adapted axes does
-/// not have homogeneous modes mixed within the irrep axes To check if the
-/// symmetry adapted axes has homogeneous modes mixed within the irreps use
-/// are_homogeneous_modes_mixed_in_irreps function
-std::vector<int> get_indices_of_homogeneous_mode_space(
-    const DoFSpace &symmetry_adapted_dof_space,
-    const ConfigEnumInput &initial_state);
 }  // namespace CASM
 
 #endif

--- a/include/casm/enumerator/DoFSpace.hh
+++ b/include/casm/enumerator/DoFSpace.hh
@@ -218,8 +218,7 @@ VectorSpaceSymReport vector_space_sym_report(DoFSpace const &dof_space,
 DoFSpace make_symmetry_adapted_dof_space(
     DoFSpace const &dof_space, ConfigEnumInput const &input_state,
     std::vector<PermuteIterator> const &group, bool calc_wedges,
-    std::optional<VectorSpaceSymReport> &symmetry_report
-    );
+    std::optional<VectorSpaceSymReport> &symmetry_report);
 
 class make_symmetry_adapted_dof_space_error : public std::runtime_error {
  public:
@@ -239,13 +238,25 @@ Eigen::MatrixXd make_homogeneous_mode_space(
 bool are_homogeneous_modes_mixed_in_irreps(
     const Eigen::MatrixXd &axes, const Eigen::MatrixXd &homogeneous_mode_space);
 
+/// Returns symmetry adapted axes with homogeneous modes removed
+/// The result of this function might be different from just the symmetry
+/// adapted axes computed using irrep decomposition and explicitly removing the
+/// homogeneous modes by identifying them using the
+/// get_indices_of_rigid_translation_space below This is implemented by
+/// computing the null space of the homogeneous mode space and using it is a
+/// subspace while performing irrep decomposition
 Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
-    const DoFSpace& symmetry_adapted_dof_space,
-    const ConfigEnumInput& initial_state);
+    const DoFSpace &symmetry_adapted_dof_space,
+    const ConfigEnumInput &initial_state);
 
-std::vector<int> get_indices_of_rigid_translation_space(
-    const DoFSpace& symmetry_adapted_dof_space,
-    const ConfigEnumInput& initial_state);
+/// Returns the column numbers of the symmetry adapted axes which are
+/// homogeneous modes This assumes that the provided symmetry adapted axes does
+/// not have homogeneous modes mixed within the irrep axes To check if the
+/// symmetry adapted axes has homogeneous modes mixed within the irreps use
+/// are_homogeneous_modes_mixed_in_irreps function
+std::vector<int> get_indices_of_homogeneous_mode_space(
+    const DoFSpace &symmetry_adapted_dof_space,
+    const ConfigEnumInput &initial_state);
 }  // namespace CASM
 
 #endif

--- a/include/casm/enumerator/io/json/DoFSpace.hh
+++ b/include/casm/enumerator/io/json/DoFSpace.hh
@@ -61,6 +61,10 @@ struct AxesCounterParams {
 /// Parse DoFSpace subspace from  "axes" and normal coordinate grid counter from
 /// "min", "max", and "increment"
 void parse(InputParser<AxesCounterParams> &parser, Index dof_space_dimension);
+
+/// Adds homogeneous mode info to the json file
+void add_homogeneous_mode_info(jsonParser &json, DoFSpace const &dofspace,
+                               ConfigEnumInput const &input_state);
 }  // namespace CASM
 
 #endif

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -404,16 +404,13 @@ struct MakeEnumerator {
     DoFSpace dof_space = make_dof_space(params.dof, initial_state, params.axes);
     std::optional<VectorSpaceSymReport> sym_report;
     ConfigEnumSiteDoFsParams params_copy = params;
-
     if (make_symmetry_adapted_axes) {  // if sym_axes==true, make and use
                                        // symmetry adapted axes
-
       log << "Performing DoF space analysis: " << name << std::endl;
       log << "For large spaces this may be slow..." << std::endl;
       bool calc_wedges = false;
       std::vector<PermuteIterator> group =
           make_invariant_subgroup(initial_state);
-
       dof_space_output.write_symmetry(index, name, initial_state, group);
       dof_space = make_symmetry_adapted_dof_space(
           dof_space, initial_state, group, calc_wedges, sym_report);
@@ -496,7 +493,6 @@ struct MakeEnumerator {
                "mixed. Proceed with caution.\n";
       }
     }
-
     dof_space_output.write_dof_space(index, dof_space, name, initial_state,
                                      sym_report);
     return ConfigEnumSiteDoFs{initial_state, params_copy};

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -355,6 +355,13 @@ void parse(InputParser<ConfigEnumSiteDoFsParams> &parser,
   // params.axes.cols()
   parser.optional_else(params.max_nonzero, "max_nonzero",
                        Index{params.axes.cols()});
+
+  // Throw error if min_nonzero exceeds max_nonzero
+  if (params.min_nonzero > params.max_nonzero) {
+    std::stringstream msg;
+    msg << "'min_nonzero' value exceeds 'max_nonzero' value" << std::endl;
+    throw std::runtime_error(msg.str());
+  }
 }
 
 void require_all_input_have_the_same_number_of_selected_sites(
@@ -448,7 +455,8 @@ struct MakeEnumerator {
         if (params_copy.axes.cols() != params_copy.min_val.rows() ||
             params_copy.axes.cols() != params_copy.max_val.rows() ||
             params_copy.axes.cols() != params_copy.inc_val.rows()) {
-          log << "Since \"sym_axes\" is set to be true along with switching "
+          std::stringstream msg;
+          msg << "Since \"sym_axes\" is set to be true along with switching "
                  "off homogeneous modes, irreps "
                  "containing "
                  "homogeneous modes will be excluded. This implies you need to "
@@ -461,13 +469,12 @@ struct MakeEnumerator {
                  "and \"inc\" to have dimensions of \""
               << params_copy.axes.cols() << "\n";
 
-          throw std::runtime_error(
-              "dimensions of \"inc\", \"max\", \"min\" do not match the "
-              "dimensionality of irreps\n");
+          throw std::runtime_error(msg.str());
         }
 
         if (params_copy.max_nonzero > params_copy.axes.cols()) {
-          log << "Since sym_axes is set to be true along with switching off "
+          std::stringstream msg;
+          msg << "Since sym_axes is set to be true along with switching off "
                  "homogeneous modes, irreps "
                  "containing "
                  "homogeneous modes will be excluded. This implies you need to "
@@ -475,8 +482,18 @@ struct MakeEnumerator {
                  "exceed "
               << params_copy.axes.cols() << "\n";
 
-          throw std::runtime_error(
-              "max_nonzero exceeds the dimensionality of the irreps\n");
+          throw std::runtime_error(msg.str());
+        }
+
+        if (params_copy.min_nonzero > params_copy.axes.cols()) {
+          std::stringstream msg;
+          msg << "Since sym_axes is set to be true along with switching off "
+                 "homogeneous modes, irreps containing homogeneous modes will "
+                 "be excluded. This implies you need to set your "
+                 "\"min_nonzero\" to not exceed your new maximum "
+                 "\"max_nonzero\": "
+              << params_copy.axes.cols() << "value\n";
+          throw std::runtime_error(msg.str());
         }
       }
 

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -419,6 +419,9 @@ struct MakeEnumerator {
           dof_space, initial_state, group, calc_wedges, sym_report);
       params_copy.axes = dof_space.basis();
 
+      // If exclude homogeneous modes is true resize all the inc, min, max
+      // values and explicitly compute the symmetry adapted axes without
+      // homogeneous modes
       if (exclude_homogeneous_modes == true) {
         log << "Excluding homogeneous modes..." << std::endl;
 
@@ -555,6 +558,9 @@ void ConfigEnumSiteDoFsInterface::run(
   parser.optional_else(exclude_homogeneous_modes, "exclude_homogeneous_modes",
                        false);
 
+  // If sym_axes is false along with exclude_homogeneous_modes true,
+  // throw an error as we do not have it implemented in the current section of
+  // the code
   if (sym_axes_option == false && exclude_homogeneous_modes == true) {
     log << "You cannot set exclude_homogeneous_modes to be true when using "
            "custom axes. Alternatives: \n 1) Use "

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -355,9 +355,6 @@ void parse(InputParser<ConfigEnumSiteDoFsParams> &parser,
   // params.axes.cols()
   parser.optional_else(params.max_nonzero, "max_nonzero",
                        Index{params.axes.cols()});
-
-  // 5) get homogeneous modes
-  parser.optional_else(params.exclude_homogeneous_modes, "exclude_homogeneous_modes", false);
 }
 
 void require_all_input_have_the_same_number_of_selected_sites(
@@ -388,15 +385,18 @@ namespace ConfigEnumSiteDoFsInterface_impl {
 struct MakeEnumerator {
   MakeEnumerator(ConfigEnumSiteDoFsParams const &_params,
                  bool _make_symmetry_adapted_axes,
+                 bool _exclude_homogeneous_modes,
                  DoFSpaceIO::SequentialDirectoryOutput &_dof_space_output)
       : log(CASM::log()),
         params(_params),
         make_symmetry_adapted_axes(_make_symmetry_adapted_axes),
+        exclude_homogeneous_modes(_exclude_homogeneous_modes),
         dof_space_output(_dof_space_output) {}
 
   Log &log;
   ConfigEnumSiteDoFsParams const &params;
   bool make_symmetry_adapted_axes;
+  bool exclude_homogeneous_modes;
   DoFSpaceIO::SequentialDirectoryOutput &dof_space_output;
 
   ConfigEnumSiteDoFs operator()(Index index, std::string name,
@@ -404,20 +404,6 @@ struct MakeEnumerator {
     DoFSpace dof_space = make_dof_space(params.dof, initial_state, params.axes);
     std::optional<VectorSpaceSymReport> sym_report;
     ConfigEnumSiteDoFsParams params_copy = params;
-
-    std::vector<Index> dof_dims;
-    auto const &dof_info =
-        initial_state.configuration().configdof().local_dof(params.dof).info();
-    for (Index l : initial_state.sites()) {
-      dof_dims.push_back(
-          dof_info[initial_state.configuration().sublat(l)].dim());
-    }
-
-    Eigen::MatrixXd axes;
-    Eigen::VectorXd inc_val = params.inc_val;
-    Eigen::VectorXd min_val = params.min_val;
-    Eigen::VectorXd max_val = params.max_val;
-    Index max_nonzero = params.max_nonzero;
 
     if (make_symmetry_adapted_axes) {  // if sym_axes==true, make and use
                                        // symmetry adapted axes
@@ -427,41 +413,41 @@ struct MakeEnumerator {
       bool calc_wedges = false;
       std::vector<PermuteIterator> group =
           make_invariant_subgroup(initial_state);
-      std::vector<SymRepTools::IrrepInfo> irreps;
 
-      Eigen::MatrixXd homogeneous_mode_space =
-          make_homogeneous_mode_space(dof_info);
-      if (params.exclude_homogeneous_modes == true) {
-        Eigen::MatrixXd null_space =
-            homogeneous_mode_space.transpose().fullPivLu().kernel();
+      dof_space_output.write_symmetry(index, name, initial_state, group);
+      dof_space = make_symmetry_adapted_dof_space(
+          dof_space, initial_state, group, calc_wedges, sym_report);
+      params_copy.axes = dof_space.basis();
 
-        irreps = irrep_decomposition(
-            initial_state.sites().begin(), initial_state.sites().end(),
-            initial_state.configuration().supercell().sym_info(), params.dof,
-            group, null_space);
+      if (exclude_homogeneous_modes == true) {
+        log << "Excluding homogeneous modes..." << std::endl;
 
-        axes = full_trans_mat(irreps).transpose();
+        params_copy.axes = symmetry_adapted_axes_without_homogeneous_modes(
+            dof_space, initial_state);
 
-        if (almost_zero(min_val)) {
-          min_val.conservativeResize(axes.cols());
+        if (almost_zero(params_copy.min_val)) {
+          params_copy.min_val.conservativeResize(params_copy.axes.cols());
         }
 
-        if (almost_zero(inc_val - Eigen::VectorXd::Constant(inc_val.rows(),
-                                                            inc_val(0)))) {
-          inc_val.conservativeResize(axes.cols());
+        if (almost_zero(params_copy.inc_val -
+                        Eigen::VectorXd::Constant(params_copy.inc_val.rows(),
+                                                  params_copy.inc_val(0)))) {
+          params_copy.inc_val.conservativeResize(params_copy.axes.cols());
         }
 
-        if (almost_zero(max_val - Eigen::VectorXd::Constant(max_val.rows(),
-                                                            max_val(0)))) {
-          max_val.conservativeResize(axes.cols());
+        if (almost_zero(params_copy.max_val -
+                        Eigen::VectorXd::Constant(params_copy.max_val.rows(),
+                                                  params_copy.max_val(0)))) {
+          params_copy.max_val.conservativeResize(params_copy.axes.cols());
         }
 
-        if (max_nonzero == params.axes.cols()) {
-          max_nonzero = axes.cols();
+        if (params_copy.max_nonzero == dof_space.basis().cols()) {
+          params_copy.max_nonzero = params_copy.axes.cols();
         }
 
-        if (axes.cols() != min_val.rows() || axes.cols() != max_val.rows() ||
-            axes.cols() != inc_val.rows()) {
+        if (params_copy.axes.cols() != params_copy.min_val.rows() ||
+            params_copy.axes.cols() != params_copy.max_val.rows() ||
+            params_copy.axes.cols() != params_copy.inc_val.rows()) {
           log << "Since \"sym_axes\" is set to be true along with switching "
                  "off homogeneous modes, irreps "
                  "containing "
@@ -473,74 +459,39 @@ struct MakeEnumerator {
                  "the dimensionality of your "
                  "\"min\", \"max_val\" "
                  "and \"inc\" to have dimensions of \""
-              << axes.cols() << "\n";
+              << params_copy.axes.cols() << "\n";
 
           throw std::runtime_error(
               "dimensions of \"inc\", \"max\", \"min\" do not match the "
               "dimensionality of irreps\n");
         }
 
-        if (max_nonzero > axes.cols()) {
+        if (params_copy.max_nonzero > params_copy.axes.cols()) {
           log << "Since sym_axes is set to be true along with switching off "
                  "homogeneous modes, irreps "
                  "containing "
                  "homogeneous modes will be excluded. This implies you need to "
                  "set your \"max_nonzero\" to not "
                  "exceed "
-              << axes.cols() << "\n";
+              << params_copy.axes.cols() << "\n";
 
           throw std::runtime_error(
               "max_nonzero exceeds the dimensionality of the irreps\n");
         }
       }
 
-      else {
-        irreps = irrep_decomposition(
-            initial_state.sites().begin(), initial_state.sites().end(),
-            initial_state.configuration().supercell().sym_info(), params.dof,
-            group, params.axes);
+      auto const &dof_info = initial_state.configuration()
+                                 .configdof()
+                                 .local_dof(params.dof)
+                                 .info();
+      Eigen::MatrixXd homogeneous_mode_space =
+          make_homogeneous_mode_space(dof_info);
 
-        axes = full_trans_mat(irreps).transpose();
-        if (axes.cols() != params.axes.cols()) {
-          throw std::runtime_error(
-              "In ConfigEnumSiteDoFs, symmetry-adapted axes do not have same "
-              "dimension as provided axes. "
-              "Please ensure that provided axes completely span one or more of "
-              "subspaces listed above.");
-        }
-      }
-
-      if (are_homogeneous_modes_mixed_in_irreps(axes, homogeneous_mode_space)) {
+      if (are_homogeneous_modes_mixed_in_irreps(params_copy.axes,
+                                                homogeneous_mode_space)) {
         log << "WARNING! Irreps have non-homogeneous and homogeneous modes "
                "mixed. Proceed with caution.\n";
       }
-
-      log << "Enumeration will be performed using symmetry-adapted normal "
-             "coordinates as axes.\n"
-          << "Normal coordinates partition DoF space into " << irreps.size()
-          << " subspaces.\n"
-          << "Normal coordinates are:\n";
-
-      Index l = 0;
-      for (Index d = 0; d < irreps.size(); ++d) {
-        log << "Axes for irreducible representation " << (d + 1)
-            << "\n  --------------\n";
-        Index dim = irreps[d].irrep_dim();
-        for (Index i = 0; i < dim; ++i, ++l) {
-          log << axes.col(l).transpose() << "\n";
-        }
-      }
-
-      log << "----------\n";
-
-      dof_space_output.write_symmetry(index, name, initial_state, group);
-      dof_space = make_symmetry_adapted_dof_space(
-          dof_space, initial_state, group, calc_wedges, sym_report);
-      params_copy.axes = axes;
-      params_copy.inc_val = inc_val;
-      params_copy.max_val = max_val;
-      params_copy.min_val = min_val;
-      params_copy.max_nonzero = max_nonzero;
     }
 
     dof_space_output.write_dof_space(index, dof_space, name, initial_state,
@@ -599,6 +550,24 @@ void ConfigEnumSiteDoFsInterface::run(
   parser.optional_else(print_dof_space_and_quit_option,
                        "print_dof_space_and_quit", false);
 
+  // Check for "exclude_homogeneous_modes" option
+  bool exclude_homogeneous_modes;
+  parser.optional_else(exclude_homogeneous_modes, "exclude_homogeneous_modes",
+                       false);
+
+  if (sym_axes_option == false && exclude_homogeneous_modes == true) {
+    log << "You cannot set exclude_homogeneous_modes to be true when using "
+           "custom axes. Alternatives: \n 1) Use "
+           "symmetry_adapted_axes_without_homogeneous_modes provided in the "
+           "symmetry "
+           "report directly with exclude_homogeneous_modes == false \n 2) "
+           "Directly use exclude_homogeneous_modes == true without custom axes "
+           "(sym_axes = true) && exclude_homogeneous_modes == true \n"
+        << std::endl;
+    throw std::runtime_error(
+        "exclude_homogeneous_modes set to be true when using custom axes");
+  }
+
   // parse "output_dir" (optional, default = current_path)
   fs::path output_dir;
   parser.optional_else(output_dir, "output_dir", fs::current_path());
@@ -624,9 +593,9 @@ void ConfigEnumSiteDoFsInterface::run(
   // 4) Enumerate configurations ------------------
 
   DoFSpaceIO::SequentialDirectoryOutput dof_space_output{output_dir};
-  
+
   ConfigEnumSiteDoFsInterface_impl::MakeEnumerator make_enumerator_f{
-      params, sym_axes_option, dof_space_output};
+      params, sym_axes_option, exclude_homogeneous_modes, dof_space_output};
 
   typedef ConfigEnumData<ConfigEnumSiteDoFs, ConfigEnumInput>
       ConfigEnumDataType;

--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -355,6 +355,9 @@ void parse(InputParser<ConfigEnumSiteDoFsParams> &parser,
   // params.axes.cols()
   parser.optional_else(params.max_nonzero, "max_nonzero",
                        Index{params.axes.cols()});
+
+  // 5) get homogeneous modes
+  parser.optional_else(params.exclude_homogeneous_modes, "exclude_homogeneous_modes", false);
 }
 
 void require_all_input_have_the_same_number_of_selected_sites(
@@ -591,14 +594,6 @@ void ConfigEnumSiteDoFsInterface::run(
   bool sym_axes_option;
   parser.optional_else(sym_axes_option, "sym_axes", false);
 
-  bool exclude_homogeneous_modes;
-  parser.optional_else(exclude_homogeneous_modes, "exclude_homogeneous_modes",
-                       false);
-  log << "Turning off homogeneous modes...\n"; 
-
-  auto params_new_copy = params;
-  params_new_copy.exclude_homogeneous_modes = exclude_homogeneous_modes;
-
   // 3c) check for "print_dof_space_and_quit" option:
   bool print_dof_space_and_quit_option;
   parser.optional_else(print_dof_space_and_quit_option,
@@ -631,7 +626,7 @@ void ConfigEnumSiteDoFsInterface::run(
   DoFSpaceIO::SequentialDirectoryOutput dof_space_output{output_dir};
   
   ConfigEnumSiteDoFsInterface_impl::MakeEnumerator make_enumerator_f{
-      params_new_copy, sym_axes_option, dof_space_output};
+      params, sym_axes_option, dof_space_output};
 
   typedef ConfigEnumData<ConfigEnumSiteDoFs, ConfigEnumInput>
       ConfigEnumDataType;

--- a/src/casm/app/enum/standard_enumerator_interfaces.cc
+++ b/src/casm/app/enum/standard_enumerator_interfaces.cc
@@ -22,8 +22,9 @@ EnumInterfaceVector make_standard_enumerator_interfaces() {
   vec.emplace_back(notstd::make_cloneable<ConfigEnumRandomLocalInterface>());
   vec.emplace_back(
       notstd::make_cloneable<ConfigEnumRandomOccupationsInterface>());
-  // vec.emplace_back(notstd::make_cloneable<ConfigEnumSiteDoFsInterface>()); //
-  // still testing & adding features
+  vec.emplace_back(
+      notstd::make_cloneable<
+          ConfigEnumSiteDoFsInterface>());  // still testing & adding features
   vec.emplace_back(notstd::make_cloneable<ConfigEnumStrainInterface>());
   vec.emplace_back(notstd::make_cloneable<ScelEnumInterface>());
   vec.emplace_back(notstd::make_cloneable<SuperConfigEnumInterface>());

--- a/src/casm/app/enum/standard_enumerator_interfaces.cc
+++ b/src/casm/app/enum/standard_enumerator_interfaces.cc
@@ -22,9 +22,7 @@ EnumInterfaceVector make_standard_enumerator_interfaces() {
   vec.emplace_back(notstd::make_cloneable<ConfigEnumRandomLocalInterface>());
   vec.emplace_back(
       notstd::make_cloneable<ConfigEnumRandomOccupationsInterface>());
-  vec.emplace_back(
-      notstd::make_cloneable<
-          ConfigEnumSiteDoFsInterface>());  // still testing & adding features
+  vec.emplace_back(notstd::make_cloneable<ConfigEnumSiteDoFsInterface>());
   vec.emplace_back(notstd::make_cloneable<ConfigEnumStrainInterface>());
   vec.emplace_back(notstd::make_cloneable<ScelEnumInterface>());
   vec.emplace_back(notstd::make_cloneable<SuperConfigEnumInterface>());

--- a/src/casm/clex/ConfigEnumSiteDoFs.cc
+++ b/src/casm/clex/ConfigEnumSiteDoFs.cc
@@ -10,8 +10,7 @@ namespace CASM {
 ConfigEnumSiteDoFs::ConfigEnumSiteDoFs(ConfigEnumInput const &_in_config,
                                        ConfigEnumSiteDoFsParams const &params)
     : ConfigEnumSiteDoFs(_in_config, params.dof, params.axes, params.min_val,
-                         params.max_val, params.inc_val,
-                         params.min_nonzero,
+                         params.max_val, params.inc_val, params.min_nonzero,
                          params.max_nonzero) {}
 
 /// See `ConfigEnumSiteDoFsParams` for method and parameter details
@@ -20,8 +19,8 @@ ConfigEnumSiteDoFs::ConfigEnumSiteDoFs(
     Eigen::Ref<const Eigen::MatrixXd> const &_axes,
     Eigen::Ref<const Eigen::VectorXd> const &min_val,
     Eigen::Ref<const Eigen::VectorXd> const &max_val,
-    Eigen::Ref<const Eigen::VectorXd> const &inc_val,
-    Index _min_nonzero, Index _max_nonzero)
+    Eigen::Ref<const Eigen::VectorXd> const &inc_val, Index _min_nonzero,
+    Index _max_nonzero)
     :
 
       // m_current(_init.config()),
@@ -121,7 +120,7 @@ void ConfigEnumSiteDoFs::_set_dof() {
     }
   }
 
-    m_current->configdof().set_local_dof(m_dof_key, vals);
+  m_current->configdof().set_local_dof(m_dof_key, vals);
 }
 
 /// Implements _increment over all occupations

--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -9,9 +9,9 @@ namespace CASM {
 namespace DoFSpace_impl {
 
 void throw_if_missing_local_dof_requirements(
-    DoFKey const &dof_key,
-    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
-    std::optional<std::set<Index>> const &sites) {
+    DoFKey const& dof_key,
+    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
+    std::optional<std::set<Index>> const& sites) {
   if (!transformation_matrix_to_super.has_value() || !sites.has_value()) {
     std::stringstream msg;
     msg << "Error: local DoF '" << dof_key
@@ -39,11 +39,11 @@ void throw_if_missing_local_dof_requirements(
 ///        match result of `get_dof_space_dimension`.
 ///
 DoFSpace::DoFSpace(
-    std::shared_ptr<Structure const> const &_shared_prim,
-    DoFKey const &_dof_key,
-    std::optional<Eigen::Matrix3l> const &_transformation_matrix_to_super,
-    std::optional<std::set<Index>> const &_sites,
-    std::optional<Eigen::MatrixXd> const &_basis)
+    std::shared_ptr<Structure const> const& _shared_prim,
+    DoFKey const& _dof_key,
+    std::optional<Eigen::Matrix3l> const& _transformation_matrix_to_super,
+    std::optional<std::set<Index>> const& _sites,
+    std::optional<Eigen::MatrixXd> const& _basis)
     : m_shared_prim(_shared_prim),
       m_dof_key(_dof_key),
       m_transformation_matrix_to_super(_transformation_matrix_to_super),
@@ -96,28 +96,28 @@ DoFSpace::DoFSpace(
 }
 
 /// Shared prim structure
-std::shared_ptr<Structure const> const &DoFSpace::shared_prim() const {
+std::shared_ptr<Structure const> const& DoFSpace::shared_prim() const {
   return m_shared_prim;
 }
 
 /// Type of degree of freedom that is under consideration (e.g., "disp",
 /// "Hstrain", "occ")
-DoFKey const &DoFSpace::dof_key() const { return m_dof_key; }
+DoFKey const& DoFSpace::dof_key() const { return m_dof_key; }
 
 /// Specifies the supercell for a local DoF space. Has value for local DoF.
-std::optional<Eigen::Matrix3l> const &DoFSpace::transformation_matrix_to_super()
+std::optional<Eigen::Matrix3l> const& DoFSpace::transformation_matrix_to_super()
     const {
   return m_transformation_matrix_to_super;
 }
 
 /// The sites included in a local DoF space. Has value for local DoF.
-std::optional<std::set<Index>> const &DoFSpace::sites() const {
+std::optional<std::set<Index>> const& DoFSpace::sites() const {
   return m_sites;
 }
 
 /// The DoF space basis, as a column vector matrix. May be a subspace (cols <=
 /// rows).
-Eigen::MatrixXd const &DoFSpace::basis() const { return m_basis; }
+Eigen::MatrixXd const& DoFSpace::basis() const { return m_basis; }
 
 /// The DoF space dimensions (equals to number of rows in basis).
 Index DoFSpace::dim() const { return m_basis.rows(); }
@@ -126,24 +126,24 @@ Index DoFSpace::dim() const { return m_basis.rows(); }
 Index DoFSpace::subspace_dim() const { return m_basis.cols(); }
 
 /// The inverse of the DoF space basis.
-Eigen::MatrixXd const &DoFSpace::basis_inverse() const {
+Eigen::MatrixXd const& DoFSpace::basis_inverse() const {
   return m_basis_inverse;
 }
 
 /// Names the DoF corresponding to each dimension (row) of the basis
-std::vector<std::string> const &DoFSpace::axis_glossary() const {
+std::vector<std::string> const& DoFSpace::axis_glossary() const {
   return m_axis_glossary;
 }
 
 /// The supercell site_index corresponding to each dimension (row) of the basis.
 /// Has value for local DoF.
-std::optional<std::vector<Index>> const &DoFSpace::axis_site_index() const {
+std::optional<std::vector<Index>> const& DoFSpace::axis_site_index() const {
   return m_axis_site_index;
 }
 
 /// The local DoF site DoFSet component index corresponding to each dimension
 /// (row) of the basis. Has value for local DoF.
-std::optional<std::vector<Index>> const &DoFSpace::axis_dof_component() const {
+std::optional<std::vector<Index>> const& DoFSpace::axis_dof_component() const {
   return m_axis_dof_component;
 }
 
@@ -152,8 +152,8 @@ std::optional<std::vector<Index>> const &DoFSpace::axis_dof_component() const {
 /// Checks that:
 /// - The prim are equivalent
 /// - For local DoF, that the transformation_matrix_to_super are equivalent
-bool is_valid_dof_space(Configuration const &config,
-                        DoFSpace const &dof_space) {
+bool is_valid_dof_space(Configuration const& config,
+                        DoFSpace const& dof_space) {
   if (!AnisoValTraits(dof_space.dof_key()).global()) {
     if (config.supercell().shared_prim() != dof_space.shared_prim()) {
       return false;
@@ -167,8 +167,8 @@ bool is_valid_dof_space(Configuration const &config,
 }
 
 /// Throw if `!is_valid_dof_space(config, dof_space)`
-void throw_if_invalid_dof_space(Configuration const &config,
-                                DoFSpace const &dof_space) {
+void throw_if_invalid_dof_space(Configuration const& config,
+                                DoFSpace const& dof_space) {
   if (!is_valid_dof_space(config, dof_space)) {
     std::stringstream msg;
     msg << "Error: DoFSpace is not valid for given configuration." << std::endl;
@@ -177,13 +177,13 @@ void throw_if_invalid_dof_space(Configuration const &config,
 }
 
 /// Return `config` DoF value as a coordinate in the DoFSpace basis
-Eigen::VectorXd get_normal_coordinate(Configuration const &config,
-                                      DoFSpace const &dof_space) {
+Eigen::VectorXd get_normal_coordinate(Configuration const& config,
+                                      DoFSpace const& dof_space) {
   using namespace DoFSpace_impl;
   throw_if_invalid_dof_space(config, dof_space);
 
-  auto const &dof_key = dof_space.dof_key();
-  auto const &basis_inverse = dof_space.basis_inverse();
+  auto const& dof_key = dof_space.dof_key();
+  auto const& basis_inverse = dof_space.basis_inverse();
 
   if (AnisoValTraits(dof_key).global()) {
     return basis_inverse * config.configdof().global_dof(dof_key).values();
@@ -192,11 +192,11 @@ Eigen::VectorXd get_normal_coordinate(Configuration const &config,
       return basis_inverse * config.configdof().occupation().cast<double>();
     } else {
       Eigen::VectorXd vector_values = Eigen::VectorXd::Zero(dof_space.dim());
-      Eigen::MatrixXd const &matrix_values =
+      Eigen::MatrixXd const& matrix_values =
           config.configdof().local_dof(dof_key).values();
 
-      auto const &axis_dof_component = dof_space.axis_dof_component().value();
-      auto const &axis_site_index = dof_space.axis_site_index().value();
+      auto const& axis_dof_component = dof_space.axis_dof_component().value();
+      auto const& axis_site_index = dof_space.axis_site_index().value();
 
       for (Index i = 0; i < dof_space.dim(); ++i) {
         vector_values[i] =
@@ -208,8 +208,8 @@ Eigen::VectorXd get_normal_coordinate(Configuration const &config,
 }
 
 /// Set `config` DoF value from a coordinate in the DoFSpace basis
-void set_dof_value(Configuration &config, DoFSpace const &dof_space,
-                   Eigen::VectorXd const &normal_coordinate) {
+void set_dof_value(Configuration& config, DoFSpace const& dof_space,
+                   Eigen::VectorXd const& normal_coordinate) {
   using namespace DoFSpace_impl;
   throw_if_invalid_dof_space(config, dof_space);
 
@@ -221,8 +221,8 @@ void set_dof_value(Configuration &config, DoFSpace const &dof_space,
     throw std::runtime_error(msg.str());
   }
 
-  auto const &dof_key = dof_space.dof_key();
-  auto const &basis = dof_space.basis();
+  auto const& dof_key = dof_space.dof_key();
+  auto const& basis = dof_space.basis();
 
   if (AnisoValTraits(dof_key).global()) {
     config.configdof().set_global_dof(dof_key, basis * normal_coordinate);
@@ -234,12 +234,12 @@ void set_dof_value(Configuration &config, DoFSpace const &dof_space,
       throw std::runtime_error(msg.str());
     }
 
-    auto &local_dof = config.configdof().local_dof(dof_key);
+    auto& local_dof = config.configdof().local_dof(dof_key);
     Eigen::VectorXd vector_values = basis * normal_coordinate;
     Eigen::MatrixXd matrix_values = local_dof.values();
 
-    auto const &axis_dof_component = dof_space.axis_dof_component().value();
-    auto const &axis_site_index = dof_space.axis_site_index().value();
+    auto const& axis_dof_component = dof_space.axis_dof_component().value();
+    auto const& axis_site_index = dof_space.axis_site_index().value();
 
     for (Index i = 0; i < dof_space.dim(); ++i) {
       matrix_values(axis_dof_component[i], axis_site_index[i]) =
@@ -251,9 +251,9 @@ void set_dof_value(Configuration &config, DoFSpace const &dof_space,
 }
 
 Index get_dof_space_dimension(
-    DoFKey dof_key, xtal::BasicStructure const &prim,
-    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
-    std::optional<std::set<Index>> const &sites) {
+    DoFKey dof_key, xtal::BasicStructure const& prim,
+    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
+    std::optional<std::set<Index>> const& sites) {
   if (AnisoValTraits(dof_key).global()) {
     return prim.global_dof(dof_key).dim();
   } else {
@@ -267,7 +267,7 @@ Index get_dof_space_dimension(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const &site = prim.basis()[sublattice_index];
+      xtal::Site const& site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
         dof_space_dimension += site.occupant_dof().size();
       } else if (site.has_dof(dof_key)) {
@@ -280,9 +280,9 @@ Index get_dof_space_dimension(
 
 /// The axis_glossary gives names to an un-symmetrized coordinate system
 std::vector<std::string> make_axis_glossary(
-    DoFKey dof_key, xtal::BasicStructure const &prim,
-    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
-    std::optional<std::set<Index>> const &sites) {
+    DoFKey dof_key, xtal::BasicStructure const& prim,
+    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
+    std::optional<std::set<Index>> const& sites) {
   std::vector<std::string> axis_glossary;
 
   if (AnisoValTraits(dof_key).global()) {
@@ -299,16 +299,16 @@ std::vector<std::string> make_axis_glossary(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const &site = prim.basis()[sublattice_index];
+      xtal::Site const& site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
-        for (auto const &molecule : site.occupant_dof()) {
+        for (auto const& molecule : site.occupant_dof()) {
           axis_glossary.push_back("occ[" + std::to_string(site_index + 1) +
                                   "][" + molecule.name() + "]");
         }
       } else if (site.has_dof(dof_key)) {
         std::vector<std::string> tdescs =
             component_descriptions(site.dof(dof_key));
-        for (std::string const &desc : tdescs) {
+        for (std::string const& desc : tdescs) {
           axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) +
                                   "]");
         }
@@ -321,12 +321,12 @@ std::vector<std::string> make_axis_glossary(
 
 /// The axis_glossary gives names to an un-symmetrized coordinate system
 void make_dof_space_axis_info(
-    DoFKey dof_key, xtal::BasicStructure const &prim,
-    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
-    std::optional<std::set<Index>> const &sites,
-    std::vector<std::string> &axis_glossary,
-    std::optional<std::vector<Index>> &axis_site_index,
-    std::optional<std::vector<Index>> &axis_dof_component) {
+    DoFKey dof_key, xtal::BasicStructure const& prim,
+    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
+    std::optional<std::set<Index>> const& sites,
+    std::vector<std::string>& axis_glossary,
+    std::optional<std::vector<Index>>& axis_site_index,
+    std::optional<std::vector<Index>>& axis_dof_component) {
   if (AnisoValTraits(dof_key).global()) {
     axis_glossary.clear();
     axis_site_index = std::nullopt;
@@ -349,10 +349,10 @@ void make_dof_space_axis_info(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const &site = prim.basis()[sublattice_index];
+      xtal::Site const& site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
         Index i = 0;
-        for (auto const &molecule : site.occupant_dof()) {
+        for (auto const& molecule : site.occupant_dof()) {
           axis_glossary.push_back("occ[" + std::to_string(site_index + 1) +
                                   "][" + molecule.name() + "]");
           axis_dof_component->push_back(i);
@@ -363,7 +363,7 @@ void make_dof_space_axis_info(
         std::vector<std::string> tdescs =
             component_descriptions(site.dof(dof_key));
         Index i = 0;
-        for (std::string const &desc : tdescs) {
+        for (std::string const& desc : tdescs) {
           axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) +
                                   "]");
           axis_dof_component->push_back(i);
@@ -378,9 +378,9 @@ void make_dof_space_axis_info(
 
 /// Make DoFSpace using `dof_key`, transformation matrix and sites from
 /// `input_state`, and `basis`
-DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const &input_state,
-                        std::optional<Eigen::MatrixXd> const &basis) {
-  auto const &supercell = input_state.configuration().supercell();
+DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const& input_state,
+                        std::optional<Eigen::MatrixXd> const& basis) {
+  auto const& supercell = input_state.configuration().supercell();
 
   return DoFSpace(supercell.shared_prim(), dof_key,
                   supercell.sym_info().transformation_matrix_to_super(),
@@ -389,9 +389,9 @@ DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const &input_state,
 
 /// Make DoFSpace with symmetry adapated basis
 DoFSpace make_symmetry_adapted_dof_space(
-    DoFSpace const &dof_space, ConfigEnumInput const &input_state,
-    std::vector<PermuteIterator> const &group, bool calc_wedges,
-    std::optional<VectorSpaceSymReport> &symmetry_report) {
+    DoFSpace const& dof_space, ConfigEnumInput const& input_state,
+    std::vector<PermuteIterator> const& group, bool calc_wedges,
+    std::optional<VectorSpaceSymReport>& symmetry_report) {
   symmetry_report = vector_space_sym_report(
       dof_space, input_state, group.begin(), group.end(), calc_wedges);
 
@@ -406,6 +406,106 @@ DoFSpace make_symmetry_adapted_dof_space(
 
   return make_dof_space(dof_space.dof_key(), input_state,
                         symmetry_report->symmetry_adapted_dof_subspace);
+}
+
+Eigen::MatrixXd make_homogeneous_mode_space(
+    const std::vector<DoFSetInfo>& dof_info) {
+  Index tot_dim = 0;
+  for (const auto& site_dof : dof_info) {
+    tot_dim += site_dof.dim();
+  }
+
+  Eigen::MatrixXd homogeneous_mode_space(tot_dim,
+                                         dof_info[0].inv_basis().cols());
+
+  Index l = 0;
+  for (const auto& site_dof : dof_info) {
+    homogeneous_mode_space.block(l, 0, site_dof.dim(),
+                                 site_dof.inv_basis().cols()) =
+        site_dof.inv_basis();
+    l += site_dof.dim();
+  }
+
+  return homogeneous_mode_space;
+}
+
+bool are_homogeneous_modes_mixed_in_irreps(
+    const Eigen::MatrixXd& axes,
+    const Eigen::MatrixXd& homogeneous_mode_space) {
+  // Make a projection operator out of homogeneous mode space and project each
+  // of the basis vectors onto it If they have a partial projection (not full or
+  // zero) => translational modes are mixed between irreps
+  Eigen::MatrixXd proj_operator =
+      homogeneous_mode_space * homogeneous_mode_space.transpose();
+
+  for (Index i = 0; i < axes.cols(); ++i) {
+    Eigen::VectorXd col_projection = proj_operator * axes.col(i);
+    if (!col_projection.isZero(CASM::TOL)) {
+      col_projection.normalize();
+    }
+
+    if (CASM::almost_equal(col_projection, axes.col(i).normalized()) == false &&
+        col_projection.isZero(CASM::TOL) == false) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
+    const DoFSpace& symmetry_adapted_dof_space,
+    const ConfigEnumInput& initial_state) {
+  auto const& dof_info = initial_state.configuration()
+                             .configdof()
+                             .local_dof(symmetry_adapted_dof_space.dof_key())
+                             .info();
+
+  Eigen::MatrixXd homogeneous_mode_space =
+      make_homogeneous_mode_space(dof_info);
+
+  Eigen::MatrixXd null_space =
+      homogeneous_mode_space.transpose().fullPivLu().kernel();
+
+  std::vector<PermuteIterator> group = make_invariant_subgroup(initial_state);
+
+  auto irreps = irrep_decomposition(
+      initial_state.sites().begin(), initial_state.sites().end(),
+      initial_state.configuration().supercell().sym_info(),
+      symmetry_adapted_dof_space.dof_key(), group, null_space);
+
+  Eigen::MatrixXd axes = full_trans_mat(irreps).transpose();
+
+  return axes;
+}
+
+std::vector<int> get_indices_of_rigid_translation_space(
+    const DoFSpace& symmetry_adapted_dof_space,
+    const ConfigEnumInput& initial_state) {
+  std::vector<int> indices;
+  Eigen::MatrixXd sym_axes = symmetry_adapted_dof_space.basis();
+
+  auto const& dof_info = initial_state.configuration()
+                             .configdof()
+                             .local_dof(symmetry_adapted_dof_space.dof_key())
+                             .info();
+
+  Eigen::MatrixXd homogeneous_mode_space =
+      make_homogeneous_mode_space(dof_info);
+  Eigen::MatrixXd proj_operator =
+      homogeneous_mode_space * homogeneous_mode_space.transpose();
+
+  for (Index i = 0; i < sym_axes.cols(); ++i) {
+    Eigen::VectorXd col_projection = proj_operator * sym_axes.col(i);
+    if (!col_projection.isZero(CASM::TOL)) {
+      col_projection.normalize();
+    }
+    if (almost_equal(col_projection, sym_axes.col(i).normalized())) {
+      indices.push_back(i);
+    }
+  }
+
+  return indices;
 }
 
 }  // namespace CASM

--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -479,7 +479,7 @@ Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
   return axes;
 }
 
-std::vector<int> get_indices_of_rigid_translation_space(
+std::vector<int> get_indices_of_homogeneous_mode_space(
     const DoFSpace& symmetry_adapted_dof_space,
     const ConfigEnumInput& initial_state) {
   std::vector<int> indices;

--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -9,9 +9,9 @@ namespace CASM {
 namespace DoFSpace_impl {
 
 void throw_if_missing_local_dof_requirements(
-    DoFKey const& dof_key,
-    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
-    std::optional<std::set<Index>> const& sites) {
+    DoFKey const &dof_key,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites) {
   if (!transformation_matrix_to_super.has_value() || !sites.has_value()) {
     std::stringstream msg;
     msg << "Error: local DoF '" << dof_key
@@ -39,11 +39,11 @@ void throw_if_missing_local_dof_requirements(
 ///        match result of `get_dof_space_dimension`.
 ///
 DoFSpace::DoFSpace(
-    std::shared_ptr<Structure const> const& _shared_prim,
-    DoFKey const& _dof_key,
-    std::optional<Eigen::Matrix3l> const& _transformation_matrix_to_super,
-    std::optional<std::set<Index>> const& _sites,
-    std::optional<Eigen::MatrixXd> const& _basis)
+    std::shared_ptr<Structure const> const &_shared_prim,
+    DoFKey const &_dof_key,
+    std::optional<Eigen::Matrix3l> const &_transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &_sites,
+    std::optional<Eigen::MatrixXd> const &_basis)
     : m_shared_prim(_shared_prim),
       m_dof_key(_dof_key),
       m_transformation_matrix_to_super(_transformation_matrix_to_super),
@@ -96,28 +96,28 @@ DoFSpace::DoFSpace(
 }
 
 /// Shared prim structure
-std::shared_ptr<Structure const> const& DoFSpace::shared_prim() const {
+std::shared_ptr<Structure const> const &DoFSpace::shared_prim() const {
   return m_shared_prim;
 }
 
 /// Type of degree of freedom that is under consideration (e.g., "disp",
 /// "Hstrain", "occ")
-DoFKey const& DoFSpace::dof_key() const { return m_dof_key; }
+DoFKey const &DoFSpace::dof_key() const { return m_dof_key; }
 
 /// Specifies the supercell for a local DoF space. Has value for local DoF.
-std::optional<Eigen::Matrix3l> const& DoFSpace::transformation_matrix_to_super()
+std::optional<Eigen::Matrix3l> const &DoFSpace::transformation_matrix_to_super()
     const {
   return m_transformation_matrix_to_super;
 }
 
 /// The sites included in a local DoF space. Has value for local DoF.
-std::optional<std::set<Index>> const& DoFSpace::sites() const {
+std::optional<std::set<Index>> const &DoFSpace::sites() const {
   return m_sites;
 }
 
 /// The DoF space basis, as a column vector matrix. May be a subspace (cols <=
 /// rows).
-Eigen::MatrixXd const& DoFSpace::basis() const { return m_basis; }
+Eigen::MatrixXd const &DoFSpace::basis() const { return m_basis; }
 
 /// The DoF space dimensions (equals to number of rows in basis).
 Index DoFSpace::dim() const { return m_basis.rows(); }
@@ -126,24 +126,24 @@ Index DoFSpace::dim() const { return m_basis.rows(); }
 Index DoFSpace::subspace_dim() const { return m_basis.cols(); }
 
 /// The inverse of the DoF space basis.
-Eigen::MatrixXd const& DoFSpace::basis_inverse() const {
+Eigen::MatrixXd const &DoFSpace::basis_inverse() const {
   return m_basis_inverse;
 }
 
 /// Names the DoF corresponding to each dimension (row) of the basis
-std::vector<std::string> const& DoFSpace::axis_glossary() const {
+std::vector<std::string> const &DoFSpace::axis_glossary() const {
   return m_axis_glossary;
 }
 
 /// The supercell site_index corresponding to each dimension (row) of the basis.
 /// Has value for local DoF.
-std::optional<std::vector<Index>> const& DoFSpace::axis_site_index() const {
+std::optional<std::vector<Index>> const &DoFSpace::axis_site_index() const {
   return m_axis_site_index;
 }
 
 /// The local DoF site DoFSet component index corresponding to each dimension
 /// (row) of the basis. Has value for local DoF.
-std::optional<std::vector<Index>> const& DoFSpace::axis_dof_component() const {
+std::optional<std::vector<Index>> const &DoFSpace::axis_dof_component() const {
   return m_axis_dof_component;
 }
 
@@ -152,8 +152,8 @@ std::optional<std::vector<Index>> const& DoFSpace::axis_dof_component() const {
 /// Checks that:
 /// - The prim are equivalent
 /// - For local DoF, that the transformation_matrix_to_super are equivalent
-bool is_valid_dof_space(Configuration const& config,
-                        DoFSpace const& dof_space) {
+bool is_valid_dof_space(Configuration const &config,
+                        DoFSpace const &dof_space) {
   if (!AnisoValTraits(dof_space.dof_key()).global()) {
     if (config.supercell().shared_prim() != dof_space.shared_prim()) {
       return false;
@@ -167,8 +167,8 @@ bool is_valid_dof_space(Configuration const& config,
 }
 
 /// Throw if `!is_valid_dof_space(config, dof_space)`
-void throw_if_invalid_dof_space(Configuration const& config,
-                                DoFSpace const& dof_space) {
+void throw_if_invalid_dof_space(Configuration const &config,
+                                DoFSpace const &dof_space) {
   if (!is_valid_dof_space(config, dof_space)) {
     std::stringstream msg;
     msg << "Error: DoFSpace is not valid for given configuration." << std::endl;
@@ -177,13 +177,13 @@ void throw_if_invalid_dof_space(Configuration const& config,
 }
 
 /// Return `config` DoF value as a coordinate in the DoFSpace basis
-Eigen::VectorXd get_normal_coordinate(Configuration const& config,
-                                      DoFSpace const& dof_space) {
+Eigen::VectorXd get_normal_coordinate(Configuration const &config,
+                                      DoFSpace const &dof_space) {
   using namespace DoFSpace_impl;
   throw_if_invalid_dof_space(config, dof_space);
 
-  auto const& dof_key = dof_space.dof_key();
-  auto const& basis_inverse = dof_space.basis_inverse();
+  auto const &dof_key = dof_space.dof_key();
+  auto const &basis_inverse = dof_space.basis_inverse();
 
   if (AnisoValTraits(dof_key).global()) {
     return basis_inverse * config.configdof().global_dof(dof_key).values();
@@ -192,11 +192,11 @@ Eigen::VectorXd get_normal_coordinate(Configuration const& config,
       return basis_inverse * config.configdof().occupation().cast<double>();
     } else {
       Eigen::VectorXd vector_values = Eigen::VectorXd::Zero(dof_space.dim());
-      Eigen::MatrixXd const& matrix_values =
+      Eigen::MatrixXd const &matrix_values =
           config.configdof().local_dof(dof_key).values();
 
-      auto const& axis_dof_component = dof_space.axis_dof_component().value();
-      auto const& axis_site_index = dof_space.axis_site_index().value();
+      auto const &axis_dof_component = dof_space.axis_dof_component().value();
+      auto const &axis_site_index = dof_space.axis_site_index().value();
 
       for (Index i = 0; i < dof_space.dim(); ++i) {
         vector_values[i] =
@@ -208,8 +208,8 @@ Eigen::VectorXd get_normal_coordinate(Configuration const& config,
 }
 
 /// Set `config` DoF value from a coordinate in the DoFSpace basis
-void set_dof_value(Configuration& config, DoFSpace const& dof_space,
-                   Eigen::VectorXd const& normal_coordinate) {
+void set_dof_value(Configuration &config, DoFSpace const &dof_space,
+                   Eigen::VectorXd const &normal_coordinate) {
   using namespace DoFSpace_impl;
   throw_if_invalid_dof_space(config, dof_space);
 
@@ -221,8 +221,8 @@ void set_dof_value(Configuration& config, DoFSpace const& dof_space,
     throw std::runtime_error(msg.str());
   }
 
-  auto const& dof_key = dof_space.dof_key();
-  auto const& basis = dof_space.basis();
+  auto const &dof_key = dof_space.dof_key();
+  auto const &basis = dof_space.basis();
 
   if (AnisoValTraits(dof_key).global()) {
     config.configdof().set_global_dof(dof_key, basis * normal_coordinate);
@@ -234,12 +234,12 @@ void set_dof_value(Configuration& config, DoFSpace const& dof_space,
       throw std::runtime_error(msg.str());
     }
 
-    auto& local_dof = config.configdof().local_dof(dof_key);
+    auto &local_dof = config.configdof().local_dof(dof_key);
     Eigen::VectorXd vector_values = basis * normal_coordinate;
     Eigen::MatrixXd matrix_values = local_dof.values();
 
-    auto const& axis_dof_component = dof_space.axis_dof_component().value();
-    auto const& axis_site_index = dof_space.axis_site_index().value();
+    auto const &axis_dof_component = dof_space.axis_dof_component().value();
+    auto const &axis_site_index = dof_space.axis_site_index().value();
 
     for (Index i = 0; i < dof_space.dim(); ++i) {
       matrix_values(axis_dof_component[i], axis_site_index[i]) =
@@ -251,9 +251,9 @@ void set_dof_value(Configuration& config, DoFSpace const& dof_space,
 }
 
 Index get_dof_space_dimension(
-    DoFKey dof_key, xtal::BasicStructure const& prim,
-    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
-    std::optional<std::set<Index>> const& sites) {
+    DoFKey dof_key, xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites) {
   if (AnisoValTraits(dof_key).global()) {
     return prim.global_dof(dof_key).dim();
   } else {
@@ -267,7 +267,7 @@ Index get_dof_space_dimension(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const& site = prim.basis()[sublattice_index];
+      xtal::Site const &site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
         dof_space_dimension += site.occupant_dof().size();
       } else if (site.has_dof(dof_key)) {
@@ -280,9 +280,9 @@ Index get_dof_space_dimension(
 
 /// The axis_glossary gives names to an un-symmetrized coordinate system
 std::vector<std::string> make_axis_glossary(
-    DoFKey dof_key, xtal::BasicStructure const& prim,
-    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
-    std::optional<std::set<Index>> const& sites) {
+    DoFKey dof_key, xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites) {
   std::vector<std::string> axis_glossary;
 
   if (AnisoValTraits(dof_key).global()) {
@@ -299,16 +299,16 @@ std::vector<std::string> make_axis_glossary(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const& site = prim.basis()[sublattice_index];
+      xtal::Site const &site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
-        for (auto const& molecule : site.occupant_dof()) {
+        for (auto const &molecule : site.occupant_dof()) {
           axis_glossary.push_back("occ[" + std::to_string(site_index + 1) +
                                   "][" + molecule.name() + "]");
         }
       } else if (site.has_dof(dof_key)) {
         std::vector<std::string> tdescs =
             component_descriptions(site.dof(dof_key));
-        for (std::string const& desc : tdescs) {
+        for (std::string const &desc : tdescs) {
           axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) +
                                   "]");
         }
@@ -321,12 +321,12 @@ std::vector<std::string> make_axis_glossary(
 
 /// The axis_glossary gives names to an un-symmetrized coordinate system
 void make_dof_space_axis_info(
-    DoFKey dof_key, xtal::BasicStructure const& prim,
-    std::optional<Eigen::Matrix3l> const& transformation_matrix_to_super,
-    std::optional<std::set<Index>> const& sites,
-    std::vector<std::string>& axis_glossary,
-    std::optional<std::vector<Index>>& axis_site_index,
-    std::optional<std::vector<Index>>& axis_dof_component) {
+    DoFKey dof_key, xtal::BasicStructure const &prim,
+    std::optional<Eigen::Matrix3l> const &transformation_matrix_to_super,
+    std::optional<std::set<Index>> const &sites,
+    std::vector<std::string> &axis_glossary,
+    std::optional<std::vector<Index>> &axis_site_index,
+    std::optional<std::vector<Index>> &axis_dof_component) {
   if (AnisoValTraits(dof_key).global()) {
     axis_glossary.clear();
     axis_site_index = std::nullopt;
@@ -349,10 +349,10 @@ void make_dof_space_axis_info(
     for (Index site_index : *sites) {
       Index sublattice_index =
           unitcellcoord_index_converter(site_index).sublattice();
-      xtal::Site const& site = prim.basis()[sublattice_index];
+      xtal::Site const &site = prim.basis()[sublattice_index];
       if (dof_key == "occ") {
         Index i = 0;
-        for (auto const& molecule : site.occupant_dof()) {
+        for (auto const &molecule : site.occupant_dof()) {
           axis_glossary.push_back("occ[" + std::to_string(site_index + 1) +
                                   "][" + molecule.name() + "]");
           axis_dof_component->push_back(i);
@@ -363,7 +363,7 @@ void make_dof_space_axis_info(
         std::vector<std::string> tdescs =
             component_descriptions(site.dof(dof_key));
         Index i = 0;
-        for (std::string const& desc : tdescs) {
+        for (std::string const &desc : tdescs) {
           axis_glossary.push_back(desc + "[" + std::to_string(site_index + 1) +
                                   "]");
           axis_dof_component->push_back(i);
@@ -378,9 +378,9 @@ void make_dof_space_axis_info(
 
 /// Make DoFSpace using `dof_key`, transformation matrix and sites from
 /// `input_state`, and `basis`
-DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const& input_state,
-                        std::optional<Eigen::MatrixXd> const& basis) {
-  auto const& supercell = input_state.configuration().supercell();
+DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const &input_state,
+                        std::optional<Eigen::MatrixXd> const &basis) {
+  auto const &supercell = input_state.configuration().supercell();
 
   return DoFSpace(supercell.shared_prim(), dof_key,
                   supercell.sym_info().transformation_matrix_to_super(),
@@ -389,9 +389,9 @@ DoFSpace make_dof_space(DoFKey dof_key, ConfigEnumInput const& input_state,
 
 /// Make DoFSpace with symmetry adapated basis
 DoFSpace make_symmetry_adapted_dof_space(
-    DoFSpace const& dof_space, ConfigEnumInput const& input_state,
-    std::vector<PermuteIterator> const& group, bool calc_wedges,
-    std::optional<VectorSpaceSymReport>& symmetry_report) {
+    DoFSpace const &dof_space, ConfigEnumInput const &input_state,
+    std::vector<PermuteIterator> const &group, bool calc_wedges,
+    std::optional<VectorSpaceSymReport> &symmetry_report) {
   symmetry_report = vector_space_sym_report(
       dof_space, input_state, group.begin(), group.end(), calc_wedges);
 
@@ -409,7 +409,7 @@ DoFSpace make_symmetry_adapted_dof_space(
 }
 
 Eigen::MatrixXd make_homogeneous_mode_space(
-    const std::vector<DoFSetInfo>& dof_info) {
+    std::vector<DoFSetInfo> const &dof_info) {
   Index tot_dim = 0;
   for (const auto& site_dof : dof_info) {
     tot_dim += site_dof.dim();
@@ -429,33 +429,36 @@ Eigen::MatrixXd make_homogeneous_mode_space(
   return homogeneous_mode_space;
 }
 
-bool are_homogeneous_modes_mixed_in_irreps(
-    const Eigen::MatrixXd& axes,
-    const Eigen::MatrixXd& homogeneous_mode_space) {
+VectorSpaceMixingInfo::VectorSpaceMixingInfo(
+    Eigen::MatrixXd const &column_vector_space, Eigen::MatrixXd const &subspace,
+    double tol) {
   // Make a projection operator out of homogeneous mode space and project each
   // of the basis vectors onto it If they have a partial projection (not full or
   // zero) => translational modes are mixed between irreps
-  Eigen::MatrixXd proj_operator =
-      homogeneous_mode_space * homogeneous_mode_space.transpose();
-
-  for (Index i = 0; i < axes.cols(); ++i) {
-    Eigen::VectorXd col_projection = proj_operator * axes.col(i);
-    if (!col_projection.isZero(CASM::TOL)) {
-      col_projection.normalize();
+  Eigen::MatrixXd proj_operator = subspace * subspace.transpose();
+  for (Index i = 0; i < column_vector_space.cols(); ++i) {
+    Eigen::VectorXd col_projection = proj_operator * column_vector_space.col(i);
+    if (col_projection.isZero(tol)) {
+      axes_not_in_subspace.push_back(i);
+    } else if (CASM::almost_equal(col_projection.normalized(),
+                                  column_vector_space.col(i).normalized(),
+                                  tol)) {
+      axes_in_subspace.push_back(i);
     }
 
-    if (CASM::almost_equal(col_projection, axes.col(i).normalized()) == false &&
-        col_projection.isZero(CASM::TOL) == false) {
-      return true;
+    else {
+      axes_mixed_with_subspace.push_back(i);
     }
   }
 
-  return false;
+  if (axes_mixed_with_subspace.size() == 0) {
+    are_axes_mixed_with_subspace = false;
+  }
 }
 
 Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
-    const DoFSpace& symmetry_adapted_dof_space,
-    const ConfigEnumInput& initial_state) {
+    DoFSpace const &symmetry_adapted_dof_space,
+    ConfigEnumInput const &initial_state) {
   auto const& dof_info = initial_state.configuration()
                              .configdof()
                              .local_dof(symmetry_adapted_dof_space.dof_key())
@@ -478,34 +481,4 @@ Eigen::MatrixXd symmetry_adapted_axes_without_homogeneous_modes(
 
   return axes;
 }
-
-std::vector<int> get_indices_of_homogeneous_mode_space(
-    const DoFSpace& symmetry_adapted_dof_space,
-    const ConfigEnumInput& initial_state) {
-  std::vector<int> indices;
-  Eigen::MatrixXd sym_axes = symmetry_adapted_dof_space.basis();
-
-  auto const& dof_info = initial_state.configuration()
-                             .configdof()
-                             .local_dof(symmetry_adapted_dof_space.dof_key())
-                             .info();
-
-  Eigen::MatrixXd homogeneous_mode_space =
-      make_homogeneous_mode_space(dof_info);
-  Eigen::MatrixXd proj_operator =
-      homogeneous_mode_space * homogeneous_mode_space.transpose();
-
-  for (Index i = 0; i < sym_axes.cols(); ++i) {
-    Eigen::VectorXd col_projection = proj_operator * sym_axes.col(i);
-    if (!col_projection.isZero(CASM::TOL)) {
-      col_projection.normalize();
-    }
-    if (almost_equal(col_projection, sym_axes.col(i).normalized())) {
-      indices.push_back(i);
-    }
-  }
-
-  return indices;
-}
-
 }  // namespace CASM

--- a/src/casm/enumerator/io/json/DoFSpace.cc
+++ b/src/casm/enumerator/io/json/DoFSpace.cc
@@ -78,7 +78,7 @@ jsonParser &to_json(DoFSpace const &dofspace, jsonParser &json,
           "enumeration";
     } else {
       std::vector<int> indices =
-          get_indices_of_rigid_translation_space(dofspace, input_state.value());
+          get_indices_of_homogeneous_mode_space(dofspace, input_state.value());
       std::vector<std::string> string_of_indices;
       for (auto i : indices) {
         std::string s = "q" + std::to_string(i + 1);

--- a/src/casm/enumerator/io/json/DoFSpace.cc
+++ b/src/casm/enumerator/io/json/DoFSpace.cc
@@ -57,44 +57,45 @@ jsonParser &to_json(DoFSpace const &dofspace, jsonParser &json,
   }
   if (sym_report.has_value()) {
     to_json(sym_report, json);
-  }
-
-  if (dofspace.dof_key() == "disp" && input_state.has_value()) {
-    Eigen::MatrixXd sym_axes = dofspace.basis();
-    auto const &dof_info = input_state.value()
-                               .configuration()
-                               .configdof()
-                               .local_dof(dofspace.dof_key())
-                               .info();
-    Eigen::MatrixXd homogeneous_mode_space =
-        make_homogeneous_mode_space(dof_info);
-    if (are_homogeneous_modes_mixed_in_irreps(sym_axes,
-                                              homogeneous_mode_space)) {
-      json["components_of_sym_axes_which_are_homogeneous_modes"] =
-          "WARNING!! Computed sym_axes has homogeneous modes mixed. Please "
-          "explicitly use the "
-          "\"symmetry_adapted_axes_without_homogeneous_modes\" provided below "
-          "or directly use the tag \"exclude_homogeneous_modes\" = true while "
-          "enumeration";
-    } else {
-      std::vector<int> indices =
-          get_indices_of_homogeneous_mode_space(dofspace, input_state.value());
-      std::vector<std::string> string_of_indices;
-      for (auto i : indices) {
-        std::string s = "q" + std::to_string(i + 1);
-        string_of_indices.push_back(s);
-      }
-      json["components_of_sym_axes_which_are_homogeneous_modes"] =
-          string_of_indices;
+    if (input_state.has_value() && dofspace.dof_key() == "disp") {
+      add_homogeneous_mode_info(json, dofspace, input_state.value());
     }
-
-    json["symmetry_adapted_axes_without_homogeneous_modes"] =
-        symmetry_adapted_axes_without_homogeneous_modes(dofspace,
-                                                        input_state.value())
-            .transpose();
   }
-
   return json;
+}
+
+void add_homogeneous_mode_info(jsonParser &json, DoFSpace const &dofspace,
+                               ConfigEnumInput const &input_state) {
+  jsonParser &irreps_json = json["irreducible_representations"];
+  Eigen::MatrixXd sym_axes = dofspace.basis();
+  auto const &dof_info = input_state.configuration()
+                             .configdof()
+                             .local_dof(dofspace.dof_key())
+                             .info();
+  Eigen::MatrixXd homogeneous_mode_space =
+      make_homogeneous_mode_space(dof_info);
+
+  auto print_string = [&](std::vector<Index> const &indices) {
+    std::vector<std::string> string_of_indices;
+    for (auto &i : indices) {
+      std::string s = "q" + std::to_string(i + 1);
+      string_of_indices.push_back(s);
+    }
+    return string_of_indices;
+  };
+
+  irreps_json["adapted_axes_without_homogeneous_modes"] =
+      symmetry_adapted_axes_without_homogeneous_modes(dofspace, input_state)
+          .transpose();
+
+  VectorSpaceMixingInfo mixing_info(sym_axes, homogeneous_mode_space,
+                                    CASM::TOL);
+  irreps_json["adapted_axes_which_are_not_homogeneous_modes"] =
+      print_string(mixing_info.axes_not_in_subspace);
+  irreps_json["adapted_axes_mixed_with_homogeneous_modes"] =
+      print_string(mixing_info.axes_mixed_with_subspace);
+  irreps_json["adapted_axes_which_are_homogeneous_modes"] =
+      print_string(mixing_info.axes_in_subspace);
 }
 
 DoFSpace jsonConstructor<DoFSpace>::from_json(

--- a/src/casm/enumerator/io/json/DoFSpace.cc
+++ b/src/casm/enumerator/io/json/DoFSpace.cc
@@ -58,6 +58,42 @@ jsonParser &to_json(DoFSpace const &dofspace, jsonParser &json,
   if (sym_report.has_value()) {
     to_json(sym_report, json);
   }
+
+  if (dofspace.dof_key() == "disp" && input_state.has_value()) {
+    Eigen::MatrixXd sym_axes = dofspace.basis();
+    auto const &dof_info = input_state.value()
+                               .configuration()
+                               .configdof()
+                               .local_dof(dofspace.dof_key())
+                               .info();
+    Eigen::MatrixXd homogeneous_mode_space =
+        make_homogeneous_mode_space(dof_info);
+    if (are_homogeneous_modes_mixed_in_irreps(sym_axes,
+                                              homogeneous_mode_space)) {
+      json["components_of_sym_axes_which_are_homogeneous_modes"] =
+          "WARNING!! Computed sym_axes has homogeneous modes mixed. Please "
+          "explicitly use the "
+          "\"symmetry_adapted_axes_without_homogeneous_modes\" provided below "
+          "or directly use the tag \"exclude_homogeneous_modes\" = true while "
+          "enumeration";
+    } else {
+      std::vector<int> indices =
+          get_indices_of_rigid_translation_space(dofspace, input_state.value());
+      std::vector<std::string> string_of_indices;
+      for (auto i : indices) {
+        std::string s = "q" + std::to_string(i + 1);
+        string_of_indices.push_back(s);
+      }
+      json["components_of_sym_axes_which_are_homogeneous_modes"] =
+          string_of_indices;
+    }
+
+    json["symmetry_adapted_axes_without_homogeneous_modes"] =
+        symmetry_adapted_axes_without_homogeneous_modes(dofspace,
+                                                        input_state.value())
+            .transpose();
+  }
+
   return json;
 }
 


### PR DESCRIPTION
- Modified the [code](https://github.com/prisms-center/CASMcode-dev/pull/494#issue-496662115) that I wrote for 0.4.X dev branch to work with the refactored ConfigEnumInput classes
- Tested the code for a custom casm project & it works as expected

TODO:
- When `exclude_homogeneous_modes == true` && `sym_axes == true`, `axes` matrix is computed accordingly by ignoring the homogeneous mode space which will have dimensions lesser than the default dof space. This implies you can provide custom `inc_val` & `max_val` to be equal to the dimensions of the reduced space. But I am not able to do that currently because when parser is checking for errors in `inc_val` & `max_val` it is always using the default dof space. I need some help @bpuchala  to figure out how to change this behavior as I was not able to track where the `axes.cols() == inc_val.cols()` check is made. 