### PR TITLE
Include fixes

### DIFF
--- a/src/casm/crystallography/BasicStructureTools.cc
+++ b/src/casm/crystallography/BasicStructureTools.cc
@@ -9,6 +9,7 @@
 
 #include "casm/basis_set/Adapter.hh"
 #include "casm/basis_set/DoFIsEquivalent.hh"
+#include "casm/basis_set/DoFIsEquivalent_impl.hh"
 #include "casm/crystallography/BasicStructure.hh"
 #include "casm/crystallography/Coordinate.hh"
 #include "casm/crystallography/DoFSet.hh"
@@ -27,8 +28,8 @@
 #include "casm/global/definitions.hh"
 #include "casm/misc/CASM_Eigen_math.hh"
 #include "casm/symmetry/SymOp.hh"
-#include "submodules/eigen/Eigen/src/Core/PermutationMatrix.h"
-#include "submodules/eigen/Eigen/src/Core/util/Constants.h"
+#include "casm/external/Eigen/src/Core/PermutationMatrix.h"
+#include "casm/external/Eigen/src/Core/util/Constants.h"
 namespace {
 using namespace CASM;
 

--- a/src/casm/crystallography/LatticeMap.cc
+++ b/src/casm/crystallography/LatticeMap.cc
@@ -7,7 +7,7 @@
 #include "casm/crystallography/Strain.hh"
 #include "casm/crystallography/SymType.hh"
 #include "casm/misc/CASM_Eigen_math.hh"
-#include "submodules/eigen/Eigen/src/Core/Matrix.h"
+#include "casm/external/Eigen/src/Core/Matrix.h"
 
 namespace CASM {
 namespace xtal {

--- a/src/casm/crystallography/StrucMapping.cc
+++ b/src/casm/crystallography/StrucMapping.cc
@@ -11,10 +11,10 @@
 #include "casm/crystallography/SymTools.hh"
 #include "casm/crystallography/io/VaspIO.hh"
 #include "casm/misc/CASM_Eigen_math.hh"
-#include "submodules/eigen/Eigen/src/Core/Map.h"
-#include "submodules/eigen/Eigen/src/Core/PermutationMatrix.h"
-#include "submodules/eigen/Eigen/src/Core/util/Constants.h"
-#include "submodules/eigen/Eigen/src/Core/util/Meta.h"
+#include "casm/external/Eigen/src/Core/Map.h"
+#include "casm/external/Eigen/src/Core/PermutationMatrix.h"
+#include "casm/external/Eigen/src/Core/util/Constants.h"
+#include "Eigen/src/Core/util/Meta.h"
 
 namespace CASM {
 namespace xtal {

--- a/src/casm/crystallography/StrucMapping.cc
+++ b/src/casm/crystallography/StrucMapping.cc
@@ -14,7 +14,7 @@
 #include "casm/external/Eigen/src/Core/Map.h"
 #include "casm/external/Eigen/src/Core/PermutationMatrix.h"
 #include "casm/external/Eigen/src/Core/util/Constants.h"
-#include "Eigen/src/Core/util/Meta.h"
+#include "casm/external/Eigen/src/Core/util/Meta.h"
 
 namespace CASM {
 namespace xtal {


### PR DESCRIPTION
- Missing include which causes undefined reference error while compiling on linux using g++
- Renaming some includes 