### PR TITLE
Update vaspwrapper.py import statement

### DIFF
--- a/python/casm/casm/vaspwrapper/vaspwrapper.py
+++ b/python/casm/casm/vaspwrapper/vaspwrapper.py
@@ -4,6 +4,7 @@ from builtins import *
 import os, shutil, six, re, subprocess, json
 import warnings
 import casm.vasp.io
+from casm import vasp
 
 class VaspWrapperError(Exception):
     def __init__(self,msg):


### PR DESCRIPTION
This change imports the vasp module properly so that the error messages in lines 188-199 can throw properly if triggered.