### PR TITLE
relaxed_energy -> energy

### DIFF
--- a/include/casm/clex/ConfigIO.hh
+++ b/include/casm/clex/ConfigIO.hh
@@ -367,6 +367,8 @@ ConfigIO::GenericConfigFormatter<bool> is_canonical();
 
 ConfigIO::GenericConfigFormatter<double> relaxed_energy();
 
+ConfigIO::GenericConfigFormatter<double> energy();
+
 ConfigIO::GenericConfigFormatter<double> relaxed_energy_per_species();
 
 ConfigIO::GenericConfigFormatter<double> reference_energy();

--- a/include/casm/clex/Configuration.hh
+++ b/include/casm/clex/Configuration.hh
@@ -495,7 +495,7 @@ Eigen::VectorXd species_frac(const Configuration &config);
 Eigen::VectorXd site_frac(const Configuration &config);
 
 /// \brief Returns the relaxed energy, normalized per unit cell
-double relaxed_energy(const Configuration &config);
+double energy(const Configuration &config);
 
 /// \brief Returns the relaxed energy, normalized per species
 double relaxed_energy_per_species(const Configuration &config);
@@ -576,7 +576,7 @@ bool is_diff_trans_endpoint(const Configuration &_config);
 /// \brief returns which diff_trans _config is an endpoint of
 std::string diff_trans_endpoint_of(const Configuration &_config);
 
-bool has_relaxed_energy(const Configuration &_config);
+bool has_energy(const Configuration &_config);
 
 bool has_reference_energy(const Configuration &_config);
 

--- a/include/casm/clex/MappedProperties.hh
+++ b/include/casm/clex/MappedProperties.hh
@@ -160,7 +160,7 @@ class ScoreMappedProperties {
 
   struct Option {
     Option(Method _method = Method::minimum,
-           std::string _name = "relaxed_energy")
+           std::string _name = "energy")
         : Option(_method, _name, -1.) {}
 
     Option(Method _method, double _lattice_weight = 0.5)
@@ -180,7 +180,7 @@ class ScoreMappedProperties {
 
   /// \brief Default uses minimum relaxed_energy
   explicit ScoreMappedProperties(Option _opt = Option(Method::minimum,
-                                                      "relaxed_energy"));
+                                                      "energy"));
 
   double operator()(const MappedProperties &obj) const;
 

--- a/include/casm/database/ConfigData.hh
+++ b/include/casm/database/ConfigData.hh
@@ -101,7 +101,7 @@ GenericDatumFormatter<double, Result> lattice_deformation_cost();
 
 GenericDatumFormatter<double, Result> atomic_deformation_cost();
 
-GenericDatumFormatter<double, Result> relaxed_energy();
+GenericDatumFormatter<double, Result> energy();
 
 GenericDatumFormatter<double, Result> score();
 

--- a/src/casm/app/ProjectBuilder.cc
+++ b/src/casm/app/ProjectBuilder.cc
@@ -93,7 +93,7 @@ ProjectSettings make_default_project_settings(xtal::BasicStructure const &prim,
   settings.set_nlist_sublat_indices(default_nlist_sublat_indices(prim));
   settings.set_default_clex(default_configuration_clex());
   settings.set_required_properties("Configuration", "default",
-                                   {"relaxed_energy"});
+                                   {"energy"});
   return settings;
 }
 

--- a/src/casm/clex/ChemicalReference.cc
+++ b/src/casm/clex/ChemicalReference.cc
@@ -416,7 +416,7 @@ ChemicalReference auto_chemical_reference(const PrimClex &primclex,
     double close_dist = std::numeric_limits<double>::max();
 
     for (auto it = begin; it != end; ++it) {
-      if (!it->calc_properties().has_scalar("relaxed_energy")) {
+      if (!it->calc_properties().has_scalar("energy")) {
         continue;
       }
       double curr_dist = (target - comp(*it)).norm();

--- a/src/casm/clex/ConfigIO.cc
+++ b/src/casm/clex/ConfigIO.cc
@@ -480,13 +480,19 @@ GenericConfigFormatter<std::string> point_group_name() {
 GenericConfigFormatter<double> relaxed_energy() {
   return GenericConfigFormatter<double>(
       "relaxed_energy", "DFT relaxed energy, normalized per primitive cell",
-      CASM::relaxed_energy, has_relaxed_energy);
+      CASM::energy, has_energy);
+}
+
+GenericConfigFormatter<double> energy() {
+  return GenericConfigFormatter<double>(
+      "energy", "DFT relaxed energy, normalized per primitive cell",
+      CASM::energy, has_energy);
 }
 
 GenericConfigFormatter<double> relaxed_energy_per_species() {
   return GenericConfigFormatter<double>(
       "relaxed_energy_per_atom", "DFT relaxed energy, normalized per atom",
-      CASM::relaxed_energy_per_species, has_relaxed_energy);
+      CASM::relaxed_energy_per_species, has_energy);
 }
 
 GenericConfigFormatter<double> reference_energy() {
@@ -684,7 +690,7 @@ make_scalar_dictionary<Configuration>() {
   using namespace ConfigIO;
   ScalarAttributeDictionary<Configuration> dict;
 
-  dict.insert(Clex(), HullDist(), ClexHullDist(), Novelty(), relaxed_energy(),
+  dict.insert(Clex(), HullDist(), ClexHullDist(), Novelty(), relaxed_energy(), energy(),
               relaxed_energy_per_species(), reference_energy(),
               reference_energy_per_species(), formation_energy(),
               formation_energy_per_species(), rms_force(), atomic_deformation(),

--- a/src/casm/clex/Configuration.cc
+++ b/src/casm/clex/Configuration.cc
@@ -855,14 +855,14 @@ Eigen::VectorXd site_frac(const Configuration &config) {
 }
 
 /// \brief Returns the relaxed energy, normalized per unit cell
-double relaxed_energy(const Configuration &config) {
-  return config.calc_properties().scalar("relaxed_energy") /
+double energy(const Configuration &config) {
+  return config.calc_properties().scalar("energy") /
          config.supercell().volume();
 }
 
 /// \brief Returns the relaxed energy, normalized per species
 double relaxed_energy_per_species(const Configuration &config) {
-  return relaxed_energy(config) / n_species(config);
+  return energy(config) / n_species(config);
 }
 
 /// \brief Returns the reference energy, normalized per unit cell
@@ -879,7 +879,7 @@ double reference_energy_per_species(const Configuration &config) {
 
 /// \brief Returns the formation energy, normalized per unit cell
 double formation_energy(const Configuration &config) {
-  return relaxed_energy(config) - reference_energy(config);
+  return energy(config) - reference_energy(config);
 }
 
 /// \brief Returns the formation energy, normalized per species
@@ -1035,8 +1035,8 @@ bool is_canonical(const Configuration &_config) {
   return _config.is_canonical();
 }
 
-bool has_relaxed_energy(const Configuration &_config) {
-  return _config.calc_properties().has_scalar("relaxed_energy");
+bool has_energy(const Configuration &_config) {
+  return _config.calc_properties().has_scalar("energy");
 }
 
 bool has_reference_energy(const Configuration &_config) {
@@ -1045,7 +1045,7 @@ bool has_reference_energy(const Configuration &_config) {
 }
 
 bool has_formation_energy(const Configuration &_config) {
-  return has_relaxed_energy(_config) && has_reference_energy(_config);
+  return has_energy(_config) && has_reference_energy(_config);
 }
 
 bool has_rms_force(const Configuration &_config) {

--- a/src/casm/database/ConfigData.cc
+++ b/src/casm/database/ConfigData.cc
@@ -145,12 +145,12 @@ GenericDatumFormatter<double, ConfigIO::Result> atomic_deformation_cost() {
       });
 }
 
-GenericDatumFormatter<double, ConfigIO::Result> relaxed_energy() {
+GenericDatumFormatter<double, ConfigIO::Result> energy() {
   return GenericDatumFormatter<double, Result>(
-      "relaxed_energy", "",
-      [](const Result &res) { return res.properties.scalar("relaxed_energy"); },
+      "energy", "",
+      [](const Result &res) { return res.properties.scalar("energy"); },
       [](const Result &res) {
-        return res.properties.has_scalar("relaxed_energy");
+        return res.properties.has_scalar("energy");
       });
 }
 
@@ -212,7 +212,7 @@ void default_update_formatters(DataFormatterDictionary<Result> &dict,
               // configname(),
               data_origin(), to_configname(), is_new_config(), has_data(),
               has_complete_data(), lattice_deformation_cost(),
-              atomic_deformation_cost(), relaxed_energy(), score(db_props),
+              atomic_deformation_cost(), energy(), score(db_props),
               best_score(db_props), is_best(db_props), selected());
 }
 }  // namespace ConfigIO

--- a/src/casm/database/ConfigImport.cc
+++ b/src/casm/database/ConfigImport.cc
@@ -704,7 +704,7 @@ DataFormatter<ConfigIO::Result> Import<Configuration>::_import_formatter()
                                   "is_best",
                                   "lattice_deformation_cost",
                                   "atomic_deformation_cost",
-                                  "relaxed_energy"};
+                                  "energy"};
 
   return dict.parse(col);
 }
@@ -789,7 +789,7 @@ DataFormatter<ConfigIO::Result> Update<Configuration>::_update_formatter()
                                   "is_best",
                                   "lattice_deformation_cost",
                                   "atomic_deformation_cost",
-                                  "relaxed_energy"};
+                                  "energy"};
 
   return dict.parse(col);
 }


### PR DESCRIPTION
- Added `energy` in `ccasm query` along with `relaxed_energy`
- Replaced `relaxed_energy` & `has_relaxed_energy` functions in `Configuration.cc` with `energy` & `has_energy`
- Print `energy` column in `update_report.X` instead of `relaxed_energy`