### PR TITLE
print cluster groups with casm bset; fix issues with local clex

### DIFF
--- a/include/casm/clex/ClexBasisWriter.hh
+++ b/include/casm/clex/ClexBasisWriter.hh
@@ -71,8 +71,7 @@ std::string clexulator_member_declarations(
     std::string const &class_name, ClexBasis const &clex,
     ParamPackMixIn const &_param_pack_mix_in,
     std::vector<std::unique_ptr<OrbitFunctionTraits> > const &orbit_func_traits,
-    std::map<UnitCellCoord, std::set<UnitCellCoord> > const &_nhood,
-    std::string const &indent);
+    Index N_flower, std::string const &indent);
 //*******************************************************************************************
 
 std::string clexulator_private_method_declarations(

--- a/include/casm/clex/ClexBasisWriter_impl.hh
+++ b/include/casm/clex/ClexBasisWriter_impl.hh
@@ -32,10 +32,9 @@ void ClexBasisWriter::print_clexulator(std::string class_name,
   std::map<UnitCellCoord, std::set<UnitCellCoord> > nhood =
       ClexBasisWriter_impl::dependency_neighborhood(_tree.begin(), _tree.end());
 
-  Index N_branch = nhood.size();
-
+  Index N_flower = nhood.size();
   for (auto const &nbor : nhood)
-    N_branch = max(_nlist.neighbor_index(nbor.first) + 1, N_branch);
+    N_flower = max(_nlist.neighbor_index(nbor.first) + 1, N_flower);
 
   std::stringstream bfunc_imp_stream, bfunc_def_stream;
 
@@ -50,8 +49,8 @@ void ClexBasisWriter::print_clexulator(std::string class_name,
 
   std::string private_declarations =
       ClexBasisWriter_impl::clexulator_member_declarations(
-          class_name, clex, *m_param_pack_mix_in, _orbit_func_traits(), nhood,
-          indent + "  ");
+          class_name, clex, *m_param_pack_mix_in, _orbit_func_traits(),
+          N_flower, indent + "  ");
 
   private_declarations +=
       ClexBasisWriter_impl::clexulator_private_method_declarations(
@@ -71,11 +70,11 @@ void ClexBasisWriter::print_clexulator(std::string class_name,
   std::vector<std::string> orbit_method_names(N_corr, "zero_func");
 
   std::vector<std::vector<std::string> > flower_method_names(
-      N_branch, std::vector<std::string>(N_corr, "zero_func"));
+      N_flower, std::vector<std::string>(N_corr, "zero_func"));
 
   // this is very configuration-centric
   std::vector<std::vector<std::string> > dflower_method_names(
-      N_branch, std::vector<std::string>(N_corr, "zero_func"));
+      N_flower, std::vector<std::string>(N_corr, "zero_func"));
 
   // temporary storage for formula
   std::vector<std::string> formulae, tformulae;
@@ -720,14 +719,14 @@ std::string clexulator_constructor_definition(
   Index N_corr = clex.n_functions();
 
   // Lower bound of branch entries
-  Index N_branch = _nhood.size();
+  Index N_flower = _nhood.size();
 
   // Lower bound of maximum neighbor index
   Index N_hood = 0;
 
-  // Find exact value of N_branch and N_hood by increasing lower bounds
+  // Find exact value of N_flower and N_hood by increasing lower bounds
   for (auto const &nbor : _nhood) {
-    N_branch = max(_nlist.neighbor_index(nbor.first) + 1, N_branch);
+    N_flower = max(_nlist.neighbor_index(nbor.first) + 1, N_flower);
     for (UnitCellCoord const &ucc : nbor.second) {
       N_hood = max(_nlist.neighbor_index(ucc) + 1, N_hood);
     }

--- a/include/casm/clex/Clexulator.hh
+++ b/include/casm/clex/Clexulator.hh
@@ -26,12 +26,9 @@ class Base {
  public:
   typedef unsigned int size_type;
 
-  Base(size_type _nlist_size, size_type _corr_size)
-      : m_nlist_size(_nlist_size),
-        m_corr_size(_corr_size),
-        m_config_ptr(nullptr) {}
+  Base(size_type _nlist_size, size_type _corr_size);
 
-  virtual ~Base() {}
+  virtual ~Base();
 
   /// \brief Neighbor list size
   size_type nlist_size() const { return m_nlist_size; }
@@ -40,9 +37,7 @@ class Base {
   size_type corr_size() const { return m_corr_size; }
 
   /// \brief Clone the Clexulator
-  std::unique_ptr<Base> clone() const {
-    return std::unique_ptr<Base>(_clone());
-  }
+  std::unique_ptr<Base> clone() const;
 
   /// \brief Obtain const reference to abstract ClexParamPack object
   virtual ClexParamPack const &param_pack() const = 0;
@@ -447,19 +442,12 @@ class Clexulator {
   Clexulator(const Clexulator &B);
 
   /// \brief Move constructor
-  Clexulator(Clexulator &&B) { swap(*this, B); }
+  Clexulator(Clexulator &&B);
 
-  ~Clexulator() {
-    // ensure Clexulator is deleted before library
-    delete m_clex.release();
-  }
+  ~Clexulator();
 
   /// \brief Assignment operator
-  Clexulator &operator=(Clexulator B) {
-    swap(*this, B);
-
-    return *this;
-  }
+  Clexulator &operator=(Clexulator B);
 
   /// \brief Swap
   friend void swap(Clexulator &first, Clexulator &second) {

--- a/include/casm/clex/io/ProtoFuncsPrinter_impl.hh
+++ b/include/casm/clex/io/ProtoFuncsPrinter_impl.hh
@@ -69,18 +69,11 @@ void ProtoFuncsPrinter::operator()(const OrbitType &orbit, Log &out,
 
     auto const &clust = orbit.prototype();
     this->increase_indent(out);
-    for (const auto &coord : clust) {
-      out.indent();
-      if (opt.coord_type == INTEGRAL) {
-        out << coord;
-        out << " ";
-        Site::print_occupant_dof(coord.site(*prim_ptr).occupant_dof(), out);
-        out << std::flush;
-      } else {
-        coord.site(*prim_ptr).print(out);
-      }
-      if (opt.delim) out << opt.delim;
-      out << std::flush;
+    if (this->opt.print_coordinates) {
+      print_coordinates(*this, orbit.prototype(), out);
+    }
+    if (this->opt.print_invariant_group) {
+      this->print_invariant_group(orbit, orbit.prototype(), out);
     }
     this->decrease_indent(out);
 
@@ -109,6 +102,9 @@ jsonParser &ProtoFuncsPrinter::to_json(const OrbitType &orbit, jsonParser &json,
   json["prototype"] = orbit.prototype();
   json["linear_orbit_index"] = orbit_index;
   json["mult"] = orbit.size();
+  if (this->opt.print_invariant_group) {
+    this->print_invariant_group(orbit, orbit.prototype(), json["prototype"]);
+  }
 
   jsonParser &orbitf = json["cluster_functions"];
   orbitf = jsonParser::array();

--- a/include/casm/clusterography/io/OrbitPrinter_impl.hh
+++ b/include/casm/clusterography/io/OrbitPrinter_impl.hh
@@ -144,8 +144,9 @@ jsonParser &OrbitPrinter<_Element, ORBIT_PRINT_MODE::PROTO>::to_json(
     const OrbitType &orbit, jsonParser &json, Index orbit_index,
     Index Norbits) const {
   json.put_obj();
-  json["linear_orbit_index"] = orbit_index;
   json["prototype"] = orbit.prototype();
+  json["linear_orbit_index"] = orbit_index;
+  json["mult"] = orbit.size();
   if (this->opt.print_invariant_group) {
     this->print_invariant_group(orbit, orbit.prototype(), json["prototype"]);
   }

--- a/src/casm/clex/ClexBasisWriter.cc
+++ b/src/casm/clex/ClexBasisWriter.cc
@@ -52,10 +52,8 @@ std::string clexulator_member_declarations(
     ParamPackMixIn const &_param_pack_mix_in,
     std::vector<std::unique_ptr<OrbitFunctionTraits> > const
         &orbit_func_writers,
-    std::map<UnitCellCoord, std::set<UnitCellCoord> > const &_nhood,
-    std::string const &indent) {
+    Index N_flower, std::string const &indent) {
   Index N_corr = clex.n_functions();
-  Index N_branch = _nhood.size();
 
   std::stringstream ss;
 
@@ -102,7 +100,7 @@ std::string clexulator_member_declarations(
           "functions of scalar type "
        << specialization.second << "\n"
        << indent << "BasisFuncPtr_" << ispec << " m_flower_func_table_" << ispec
-       << "[" << N_branch << "][" << N_corr << "];\n\n"
+       << "[" << N_flower << "][" << N_corr << "];\n\n"
        <<
 
         indent
@@ -110,7 +108,7 @@ std::string clexulator_member_declarations(
           "flower functions of scalar type "
        << specialization.second << "\n"
        << indent << "DeltaBasisFuncPtr_" << ispec << " m_delta_func_table_"
-       << ispec << "[" << N_branch << "][" << N_corr << "];\n\n";
+       << ispec << "[" << N_flower << "][" << N_corr << "];\n\n";
 
     ++ispec;
   }

--- a/src/casm/clex/Clexulator.cc
+++ b/src/casm/clex/Clexulator.cc
@@ -74,9 +74,23 @@ Clexulator::Clexulator(std::string name, fs::path dirpath,
 
 /// \brief Copy constructor
 Clexulator::Clexulator(const Clexulator &B) : m_name(B.name()), m_lib(B.m_lib) {
-  if (B.m_clex.get() != nullptr) {
-    m_clex.reset(B.m_clex->clone().release());
+  if (B.m_clex != nullptr) {
+    m_clex = B.m_clex->clone();
   }
+}
+
+/// \brief Move constructor
+Clexulator::Clexulator(Clexulator &&B) { swap(*this, B); }
+
+Clexulator::~Clexulator() {
+  // ensure Clexulator is deleted before library
+  m_clex.reset();
+}
+
+/// \brief Assignment operator
+Clexulator &Clexulator::operator=(Clexulator B) {
+  swap(*this, B);
+  return *this;
 }
 
 /// \brief Obtain ClexParamKey for a particular parameter
@@ -119,6 +133,19 @@ std::string Clexulator::check_evaluation(ClexParamKey const _param_key) const {
 }
 
 namespace Clexulator_impl {
+
+Base::Base(size_type _nlist_size, size_type _corr_size)
+    : m_nlist_size(_nlist_size),
+      m_corr_size(_corr_size),
+      m_config_ptr(nullptr) {}
+
+Base::~Base() {}
+
+/// \brief Clone the Clexulator
+std::unique_ptr<Base> Base::clone() const {
+  return std::unique_ptr<Base>(_clone());
+}
+
 /// \brief Alter evaluation of parameters specified by @param _param_key, using
 /// a custom double -> double function set
 void Base::set_evaluation(

--- a/src/casm/clex/PrimClex.cc
+++ b/src/casm/clex/PrimClex.cc
@@ -467,7 +467,9 @@ struct WriteBasisSetDataImpl {
     // write clust
     fs::path clust_json_path = dir.clust(basis_set_name);
     jsonParser clust_json;
-    ProtoSitesPrinter sites_printer{};
+    OrbitPrinterOptions orbit_printer_options;
+    orbit_printer_options.print_invariant_group = true;
+    ProtoSitesPrinter sites_printer{orbit_printer_options};
     write_clust(orbits.begin(), orbits.end(), clust_json, sites_printer,
                 basis_set_specs_json);
     clust_json.write(clust_json_path);
@@ -478,7 +480,7 @@ struct WriteBasisSetDataImpl {
     write_site_basis_funcs(shared_prim, clex_basis, basis_json);
     bool align = false;
     ProtoFuncsPrinter funcs_printer{clex_basis, shared_prim->shared_structure(),
-                                    align};
+                                    align, orbit_printer_options};
     write_clust(orbits.begin(), orbits.end(), basis_json, funcs_printer,
                 basis_set_specs_json);
     basis_json.write(basis_json_path);

--- a/src/casm/clusterography/io/json/ClusterSpecs_json_io.cc
+++ b/src/casm/clusterography/io/json/ClusterSpecs_json_io.cc
@@ -301,9 +301,10 @@ void parse(InputParser<LocalMaxLengthClusterSpecs> &parser,
   auto cutoff_radius = parse_orbit_branch_specs_attr(parser, "cutoff_radius");
 
   // parse custom generators ("orbit_specs")
+  std::vector<IntegralClusterOrbitGenerator> default_custom_generators{};
   auto custom_generators_parser =
-      parser.subparse<std::vector<IntegralClusterOrbitGenerator>>("orbit_specs",
-                                                                  *shared_prim);
+      parser.subparse_else<std::vector<IntegralClusterOrbitGenerator>>(
+          "orbit_specs", default_custom_generators, *shared_prim);
 
   // TODO: include option in JSON?
   bool include_phenomenal_sites = false;

--- a/src/casm/monte_carlo/canonical/Canonical.cc
+++ b/src/casm/monte_carlo/canonical/Canonical.cc
@@ -305,7 +305,7 @@ void Canonical::_calc_delta_point_corr(Index l, int new_occ,
       _clexulator().calc_point_corr(
           _configdof(), nlist().sites(nlist().unitcell_index(l)).data(),
           end_ptr(nlist().sites(nlist().unitcell_index(l))), sublat,
-          end_ptr(before), before.data());
+          before.data(), end_ptr(before));
 
       // Apply change
       _configdof().occ(l) = new_occ;

--- a/src/casm/symmetry/SymRepTools.cc
+++ b/src/casm/symmetry/SymRepTools.cc
@@ -1234,6 +1234,9 @@ SymGroupRep permuted_direct_sum_rep(
   Eigen::MatrixXd const *rep_mat_ptr(NULL);
   Permutation const *perm_ptr;
   for (Index g = 0; g < permute_rep.size(); g++) {
+    if (permute_rep[g] == NULL) {
+      continue;
+    }
     sum_mat.setZero();
     perm_ptr = permute_rep.permutation(g);
     for (Index r = 0; r < perm_ptr->size(); r++) {


### PR DESCRIPTION
New `casm bset` options for printing to screen and controlling compilation of clexulators:

- `--print-invariant-group`
- `--print-equivalence-map`
- `--no-compile`
- `--only-compile`

Always print invariant groups in `clust.json` and `basis.json`.

Also fixes errors building local clexulators (wrong number of flower and delta functions, allow incomplete permute reps for cluster generating groups).