### PR TITLE
Fix `point_corr` and other correlation output improvements

### DIFF
--- a/include/casm/casm_io/dataformatter/DataFormatterTools.hh
+++ b/include/casm/casm_io/dataformatter/DataFormatterTools.hh
@@ -1496,11 +1496,6 @@ class Generic2DDatumFormatter
   Validator m_validate;
 };
 
-template <typename DataObject>
-MatrixXdAttributeDictionary<DataObject> make_matrixxd_dictionary() {
-  return MatrixXdAttributeDictionary<DataObject>();
-}
-
 }  // namespace CASM
 
 #endif

--- a/include/casm/clex/ClexBasisInfo.hh
+++ b/include/casm/clex/ClexBasisInfo.hh
@@ -1,0 +1,79 @@
+#ifndef CASM_ClexBasisInfo
+#define CASM_ClexBasisInfo
+
+#include <map>
+#include <set>
+
+#include "casm/clusterography/IntegralCluster_impl.hh"
+#include "casm/crystallography/UnitCellCoord.hh"
+#include "casm/global/definitions.hh"
+
+namespace CASM {
+
+struct ClexBasisSpecs;
+class PrimNeighborList;
+class Structure;
+
+/// Clex basis function info
+///
+/// Stored for each cluster expansion basis function in ClexBasisInfo
+struct ClexBasisFunctionInfo {
+  ClexBasisFunctionInfo(Index _linear_orbit_index, Index _linear_function_index,
+                        IntegralCluster _prototype, Index _multiplicity,
+                        std::vector<Index> _cluster_invariant_group_indices)
+      : linear_orbit_index(_linear_orbit_index),
+        linear_function_index(_linear_function_index),
+        prototype(_prototype),
+        multiplicity(_multiplicity),
+        cluster_invariant_group_indices(_cluster_invariant_group_indices) {}
+
+  /// \brief Linear index of the cluster orbit
+  Index linear_orbit_index;
+
+  /// \brief Linear index of the cluster basis function
+  Index linear_function_index;
+
+  /// \brief Prototype cluster
+  IntegralCluster prototype;
+
+  /// \brief Number of equivalent clusters
+  Index multiplicity;
+
+  /// \brief Indices of prim factor group operations that map this cluster onto
+  /// itself according to the symmetry used to generate clusters
+  std::vector<Index> cluster_invariant_group_indices;
+};
+
+/// Useful ClexBasis info
+///
+/// - Construct with `make_clex_basis_info`
+struct ClexBasisInfo {
+  /// \brief Information on basis functions
+  std::vector<ClexBasisFunctionInfo> basis_function_info;
+
+  /// \brief Maximum possible number of sites involved in evaluation
+  Index neighborhood_size;
+
+  /// \brief Number of point correlations
+  Index n_point_corr;
+
+  /// \brief Point correlation neighborhoods
+  ///
+  /// A map of UnitCellCoord (translated as necessary to the canonical
+  /// unit cell by the SymCompare method), to the set of UnitCellCoord that it
+  /// is in clusters with. For cluster function evaluation, this gives the
+  /// neighborhood of sites whose DoF values are needed to evaluate clusters
+  /// involving a particular site.
+  std::map<xtal::UnitCellCoord, std::set<xtal::UnitCellCoord>>
+      site_dependency_neighborhoods;
+};
+
+/// Make ClexBasisInfo
+ClexBasisInfo make_clex_basis_info(
+    std::shared_ptr<Structure const> const &shared_prim,
+    ClexBasisSpecs const &basis_set_specs,
+    PrimNeighborList &prim_neighbor_list);
+
+}  // namespace CASM
+
+#endif

--- a/include/casm/clex/ConfigCorrelations.hh
+++ b/include/casm/clex/ConfigCorrelations.hh
@@ -1,0 +1,97 @@
+#ifndef CASM_ConfigCorrelations
+#define CASM_ConfigCorrelations
+
+#include "casm/crystallography/DoFDecl.hh"
+#include "casm/global/definitions.hh"
+#include "casm/global/eigen.hh"
+
+namespace CASM {
+
+namespace xtal {
+class BasicStructure;
+class Coordinate;
+class UnitCellCoord;
+}  // namespace xtal
+
+class Clexulator;
+class ConfigDoF;
+class Configuration;
+class SuperNeighborList;
+class Supercell;
+class SupercellSymInfo;
+
+/// \brief Returns correlations using 'clexulator'. Supercell needs a correctly
+/// populated neighbor list.
+Eigen::VectorXd correlations(const ConfigDoF &configdof, const Supercell &scel,
+                             Clexulator const &clexulator);
+
+/// \brief Returns correlations using 'clexulator'.
+Eigen::VectorXd correlations(const Configuration &config,
+                             Clexulator const &clexulator);
+
+/// Returns correlation contribution from a single unit cell, not normalized.
+Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
+                                  const ConfigDoF &configdof,
+                                  const Supercell &scel,
+                                  Clexulator const &clexulator);
+
+/// \brief Returns correlations using 'clexulator'.
+Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
+                                  const Configuration &config,
+                                  Clexulator const &clexulator);
+
+/// Returns correlation contributions from all unit cells, not normalized.
+Eigen::MatrixXd all_corr_contribution(const Configuration &config,
+                                      Clexulator const &clexulator);
+
+/// \brief Returns point correlations from a single site, normalized by cluster
+/// orbit size
+Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
+                           const ConfigDoF &configdof, const Supercell &scel,
+                           Clexulator const &clexulator);
+
+/// \brief Returns point correlations from a single site, normalized by cluster
+/// orbit size
+Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
+                           const Configuration &config,
+                           Clexulator const &clexulator);
+
+/// \brief Returns point correlations from all sites, normalized by cluster
+/// orbit size
+Eigen::MatrixXd all_point_corr(const Configuration &config,
+                               Clexulator const &clexulator);
+
+/// Return a vector of xtal::Coordinate for each row in `all_point_corr`
+std::vector<xtal::UnitCellCoord> make_all_point_corr_unitcellcoord(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist);
+
+/// Return coordinates (xtal::Coordinate) for each row in `all_point_corr`
+std::vector<xtal::Coordinate> make_all_point_corr_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist);
+
+/// Return Cartesian coordinates (as rows) for each row in `all_point_corr`
+Eigen::MatrixXd make_all_point_corr_cart_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist);
+
+/// Return fractional coordinates (as rows) for each row in `all_point_corr`
+Eigen::MatrixXd make_all_point_corr_frac_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist);
+
+/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
+/// 'dof_type'
+Eigen::MatrixXd gradcorrelations(const ConfigDoF &configdof,
+                                 const Supercell &scel,
+                                 Clexulator const &clexulator, DoFKey &key);
+
+/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
+/// 'dof_type'
+Eigen::MatrixXd gradcorrelations(const Configuration &config,
+                                 Clexulator const &clexulator, DoFKey &key);
+
+}  // namespace CASM
+
+#endif

--- a/include/casm/clex/ConfigIO.hh
+++ b/include/casm/clex/ConfigIO.hh
@@ -333,6 +333,99 @@ class PointCorr : public VectorXdAttribute<Configuration> {
   mutable std::string m_clex_name;
 };
 
+/// \brief Returns correlation values for all unit cells
+///
+/// Evaluated basis function values for each unit cell, not normalized
+///
+class AllCorrContribution : public MatrixXdAttribute<Configuration> {
+ public:
+  static const std::string Name;
+
+  static const std::string Desc;
+
+  AllCorrContribution()
+      : MatrixXdAttribute<Configuration>(Name, Desc), m_clex_name("") {}
+
+  AllCorrContribution(const Clexulator &clexulator)
+      : MatrixXdAttribute<Configuration>(Name, Desc),
+        m_clexulator(clexulator) {}
+
+  // --- Required implementations -----------
+
+  /// \brief Returns the atom fraction
+  Eigen::MatrixXd evaluate(const Configuration &config) const override;
+
+  /// \brief Clone using copy constructor
+  std::unique_ptr<AllCorrContribution> clone() const {
+    return std::unique_ptr<AllCorrContribution>(this->_clone());
+  }
+
+  // --- Specialized implementation -----------
+
+  /// \brief If not yet initialized, use the global clexulator from the PrimClex
+  bool init(const Configuration &_tmplt) const override;
+
+  /// \brief Expects 'all_point_corr', 'all_point_corr(clex_name)',
+  /// 'all_point_corr(index_expression)', or
+  /// 'all_point_corr(clex_name,index_expression)'
+  bool parse_args(const std::string &args) override;
+
+ private:
+  /// \brief Clone using copy constructor
+  AllCorrContribution *_clone() const override {
+    return new AllCorrContribution(*this);
+  }
+
+  mutable Clexulator m_clexulator;
+  mutable std::string m_clex_name;
+};
+
+/// \brief Returns point correlation values
+///
+/// Evaluated basis function values for each site, normalized by cluster orbit
+/// multiplicity
+///
+class AllPointCorr : public MatrixXdAttribute<Configuration> {
+ public:
+  static const std::string Name;
+
+  static const std::string Desc;
+
+  AllPointCorr()
+      : MatrixXdAttribute<Configuration>(Name, Desc), m_clex_name("") {}
+
+  AllPointCorr(const Clexulator &clexulator)
+      : MatrixXdAttribute<Configuration>(Name, Desc),
+        m_clexulator(clexulator) {}
+
+  // --- Required implementations -----------
+
+  /// \brief Returns the atom fraction
+  Eigen::MatrixXd evaluate(const Configuration &config) const override;
+
+  /// \brief Clone using copy constructor
+  std::unique_ptr<AllPointCorr> clone() const {
+    return std::unique_ptr<AllPointCorr>(this->_clone());
+  }
+
+  // --- Specialized implementation -----------
+
+  /// \brief If not yet initialized, use the global clexulator from the PrimClex
+  bool init(const Configuration &_tmplt) const override;
+
+  /// \brief Expects 'all_point_corr', 'all_point_corr(clex_name)',
+  /// 'all_point_corr(index_expression)', or
+  /// 'all_point_corr(clex_name,index_expression)'
+  bool parse_args(const std::string &args) override;
+
+ private:
+  /// \brief Clone using copy constructor
+  AllPointCorr *_clone() const override { return new AllPointCorr(*this); }
+
+  mutable Clexulator m_clexulator;
+  mutable std::string m_clex_name;
+};
+
 /// \brief Returns correlation values
 ///
 /// Evaluated gradient of basis function values, w.r.t. specified DoF

--- a/include/casm/clex/Configuration.hh
+++ b/include/casm/clex/Configuration.hh
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "casm/clex/Calculable.hh"
+#include "casm/clex/ConfigCorrelations.hh"  // TODO: remove include
 #include "casm/clex/ConfigDoF.hh"
 #include "casm/clex/ConfigurationTraits.hh"
 #include "casm/clex/HasCanonicalForm.hh"
@@ -28,7 +29,6 @@ using xtal::UnitCellCoord;
 class IntegralCluster;
 class PrimClex;
 class Supercell;
-class Clexulator;
 class ConfigIsEquivalent;
 template <typename ConfigType, typename IsEqualImpl>
 class GenericConfigCompare;
@@ -465,26 +465,6 @@ Configuration sub_configuration(std::shared_ptr<Supercell const> sub_scel_ptr,
 /// \brief Make Configuration from name string
 Configuration make_configuration(const PrimClex &primclex, std::string name);
 
-/// \brief Returns correlations using 'clexulator'.
-Eigen::VectorXd correlations(const Configuration &config,
-                             Clexulator const &clexulator);
-
-/// Returns correlation contribution from a single unit cell, not normalized.
-Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
-                                  const Configuration &config,
-                                  Clexulator const &clexulator);
-
-/// \brief Returns point correlations from a single site, normalized by cluster
-/// orbit size
-Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
-                           const Configuration &config,
-                           Clexulator const &clexulator);
-
-/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
-/// 'dof_type'
-Eigen::MatrixXd gradcorrelations(const Configuration &config,
-                                 Clexulator const &clexulator, DoFKey &key);
-
 /// Returns parametric composition, as calculated using PrimClex::param_comp
 Eigen::VectorXd comp(const Configuration &config);
 
@@ -522,12 +502,6 @@ double formation_energy(const Configuration &config);
 
 /// \brief Returns the formation energy, normalized per species
 double formation_energy_per_species(const Configuration &config);
-
-/// \brief Returns the formation energy, normalized per unit cell
-double clex_formation_energy(const Configuration &config);
-
-/// \brief Returns the formation energy, normalized per species
-double clex_formation_energy_per_species(const Configuration &config);
 
 /// \brief Root-mean-square forces of relaxed configurations, determined from
 /// DFT (eV/Angstr.)
@@ -604,29 +578,6 @@ bool has_volume_relaxation(const Configuration &_config);
 bool has_relaxed_magmom(const Configuration &_config);
 
 bool has_relaxed_mag_basis(const Configuration &_config);
-
-/// \brief Returns correlations using 'clexulator'. Supercell needs a correctly
-/// populated neighbor list.
-Eigen::VectorXd correlations(const ConfigDoF &configdof, const Supercell &scel,
-                             Clexulator const &clexulator);
-
-/// Returns correlation contribution from a single unit cell, not normalized.
-Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
-                                  const ConfigDoF &configdof,
-                                  const Supercell &scel,
-                                  Clexulator const &clexulator);
-
-/// \brief Returns point correlations from a single site, normalized by cluster
-/// orbit size
-Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
-                           const ConfigDoF &configdof, const Supercell &scel,
-                           Clexulator const &clexulator);
-
-/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
-/// 'dof_type'
-Eigen::MatrixXd gradcorrelations(const ConfigDoF &configdof,
-                                 const Supercell &scel,
-                                 Clexulator const &clexulator, DoFKey &key);
 
 /// \brief Returns num_each_molecule(molecule_type), where 'molecule_type' is
 /// ordered as Structure::get_struc_molecule()

--- a/include/casm/clex/SupercellIO.hh
+++ b/include/casm/clex/SupercellIO.hh
@@ -216,6 +216,9 @@ VectorXiAttributeDictionary<Supercell> make_vectorxi_dictionary<Supercell>();
 template <>
 VectorXdAttributeDictionary<Supercell> make_vectorxd_dictionary<Supercell>();
 
+template <>
+MatrixXdAttributeDictionary<Supercell> make_matrixxd_dictionary<Supercell>();
+
 }  // namespace CASM
 
 #endif

--- a/include/casm/clex/io/ProtoFuncsPrinter.hh
+++ b/include/casm/clex/io/ProtoFuncsPrinter.hh
@@ -14,6 +14,7 @@ class BasicStructure;
 }
 
 class ClexBasis;
+struct ClexBasisSpecs;
 class Structure;
 class jsonParser;
 
@@ -65,6 +66,16 @@ void print_aligned_site_basis_funcs(std::shared_ptr<const Structure> prim_ptr,
 
 void write_site_basis_funcs(std::shared_ptr<const Structure> prim_ptr,
                             ClexBasis const &clex_basis, jsonParser &json);
+
+/// Write basis.json format JSON
+template <typename OrbitVecType>
+void write_clex_basis(ClexBasis const &clex_basis, OrbitVecType const &orbits,
+                      jsonParser &json);
+
+/// Write basis.json format JSON
+jsonParser write_clex_basis(std::shared_ptr<const Structure> const &shared_prim,
+                            ClexBasisSpecs const &clex_basis_specs,
+                            jsonParser &json);
 
 }  // namespace CASM
 

--- a/include/casm/clusterography/ClusterOrbits.hh
+++ b/include/casm/clusterography/ClusterOrbits.hh
@@ -3,6 +3,8 @@
 
 #include <functional>
 #include <iostream>
+#include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -154,6 +156,12 @@ OutputIterator local_neighborhood(ClusterOrbitIterator begin,
 template <typename OrbitType>
 bool has_local_neighborhood_overlap(std::vector<OrbitType> &local_orbits,
                                     const Eigen::Matrix3i &transf_mat);
+
+/// Make site dependency neighborhoods
+template <typename ClusterOrbitIterator>
+std::map<xtal::UnitCellCoord, std::set<xtal::UnitCellCoord> >
+make_site_dependency_neighborhoods(ClusterOrbitIterator begin,
+                                   ClusterOrbitIterator end);
 
 /// \brief Return superlattice transf. matrices for which
 /// has_local_neighborhood_overlap is false

--- a/include/casm/clusterography/ClusterOrbits_impl.hh
+++ b/include/casm/clusterography/ClusterOrbits_impl.hh
@@ -213,6 +213,73 @@ bool has_local_neighborhood_overlap(std::vector<OrbitType> const &local_orbits,
   return false;
 }
 
+/// Make site dependency neighborhoods
+///
+/// \param begin Iterator at the beginning of a cluster orbit range
+/// \param end Iterator at the end of a cluster orbit range
+///
+/// \returns a map of UnitCellCoord (translated as necessary to the canonical
+/// unit cell by the SymCompare method), to the set of UnitCellCoord that it is
+/// in clusters with. For cluster function evaluation, this gives the
+/// neighborhood of sites whose DoF values are needed to evaluate clusters
+/// involving a particular site.
+///
+/// Note:
+/// - keys of result are guaranteed to be in canonical translation unit
+template <typename ClusterOrbitIterator>
+std::map<xtal::UnitCellCoord, std::set<xtal::UnitCellCoord>>
+make_site_dependency_neighborhoods(ClusterOrbitIterator begin,
+                                   ClusterOrbitIterator end) {
+  std::map<xtal::UnitCellCoord, std::set<xtal::UnitCellCoord>> result;
+
+  if (begin == end) return result;
+
+  typedef IntegralCluster cluster_type;
+  typedef typename ClusterOrbitIterator::value_type orbit_type;
+
+  xtal::UnitCellCoord const *ucc_ptr(nullptr);
+  ClusterOrbitIterator begin2 = begin;
+  for (; begin2 != end; ++begin2) {
+    auto const &orbit = *begin2;
+    for (auto const &equiv : orbit) {
+      for (xtal::UnitCellCoord const &ucc : equiv) {
+        ucc_ptr = &ucc;
+        break;
+      }
+      if (ucc_ptr) break;
+    }
+    if (ucc_ptr) break;
+  }
+  if (!ucc_ptr) return result;
+
+  Structure const &prim(begin->prototype().prim());
+  SymGroup identity_group(prim.factor_group().begin(),
+                          (prim.factor_group().begin()) + 1);
+  orbit_type empty_orbit(cluster_type(prim), identity_group,
+                         begin->sym_compare());
+
+  // Loop over each site in each cluster of each orbit
+  for (; begin != end; ++begin) {
+    auto const &orbit = *begin;
+    for (auto const &equiv : orbit) {
+      for (xtal::UnitCellCoord const &ucc : equiv) {
+        // create a test cluster from prototype
+        cluster_type test(empty_orbit.prototype());
+
+        // add the new site
+        test.elements().push_back(ucc);
+        test = orbit.sym_compare().prepare(test);
+
+        xtal::UnitCell trans = test.element(0).unitcell() - ucc.unitcell();
+        for (xtal::UnitCellCoord const &ucc2 : equiv) {
+          result[test.element(0)].insert(ucc2 + trans);
+        }
+      }
+    }
+  }
+  return result;
+}
+
 /// \brief Return superlattice transf. matrices for which
 /// has_local_neighborhood_overlap is false
 ///

--- a/include/casm/clusterography/io/OrbitPrinter.hh
+++ b/include/casm/clusterography/io/OrbitPrinter.hh
@@ -192,12 +192,6 @@ jsonParser &write_clust(ClusterOrbitIterator begin, ClusterOrbitIterator end,
                         jsonParser &json,
                         const OrbitPrinterOptions &opt = OrbitPrinterOptions());
 
-/// \brief Write Orbit<SymCompareType> to JSON, including 'bspecs'
-template <typename ClusterOrbitIterator, typename Printer>
-jsonParser &write_clust(ClusterOrbitIterator begin, ClusterOrbitIterator end,
-                        jsonParser &json, Printer printer,
-                        const jsonParser &bspecs);
-
 }  // namespace CASM
 
 #endif

--- a/src/casm/app/info/methods/SupercellInfoInterface.cc
+++ b/src/casm/app/info/methods/SupercellInfoInterface.cc
@@ -153,7 +153,12 @@ SupercellInfoFormatter<jsonParser> frac_coordinate() {
   return SupercellInfoFormatter<jsonParser>(
       "frac_coordinate",
       "Fractional coordinate (with respect to the supercell lattice vectors) "
-      "of every site in the supercell.",
+      "of every site in the supercell. For coordinate conversions, the order "
+      "in which sites are listed is the same as for `cart_coordinate` and "
+      "`integral_site_coordinates`. The site order is determined by "
+      "`linear_site_index = linear_unitcell_index + supercell_volume * "
+      "sublattice_index`, where `linear_unitcell_index` is an index into the "
+      "`unitcells` list.",
       [](SupercellInfoData const &data) -> jsonParser {
         auto const &prim = *data.shared_prim;
         jsonParser json = jsonParser::array();
@@ -171,7 +176,13 @@ SupercellInfoFormatter<jsonParser> frac_coordinate() {
 
 SupercellInfoFormatter<jsonParser> cart_coordinate() {
   return SupercellInfoFormatter<jsonParser>(
-      "cart_coordinate", "Cartesian coordinate of every site in the supercell.",
+      "cart_coordinate",
+      "Cartesian coordinate of every site in the supercell. For coordinate "
+      "conversions, the order in which sites are listed is the same as for "
+      "`frac_coordinate` and `integral_site_coordinates`. The site order is "
+      "determined by `linear_site_index = linear_unitcell_index + "
+      "supercell_volume * sublattice_index`, where `linear_unitcell_index` is "
+      "an index into the `unitcells` list.",
       [](SupercellInfoData const &data) -> jsonParser {
         auto const &prim = *data.shared_prim;
         jsonParser json = jsonParser::array();

--- a/src/casm/clex/ClexBasisInfo.cc
+++ b/src/casm/clex/ClexBasisInfo.cc
@@ -1,0 +1,103 @@
+
+#include "casm/clex/ClexBasisInfo.hh"
+
+#include "casm/casm_io/Log.hh"
+#include "casm/clex/ClexBasis_impl.hh"
+#include "casm/clex/NeighborList.hh"
+#include "casm/clusterography/ClusterSpecs_impl.hh"
+#include "casm/clusterography/io/OrbitPrinter_impl.hh"
+
+namespace CASM {
+
+namespace {
+
+/// Implementation for `make_clex_basis_info`
+class MakeClexBasisInfo {
+ public:
+  /// Required input & resulting `clex_basis_info` to be populated
+  MakeClexBasisInfo(std::shared_ptr<Structure const> _shared_prim,
+                    ClexBasisSpecs const &_basis_set_specs,
+                    PrimNeighborList &_prim_neighbor_list,
+                    ClexBasisInfo &_clex_basis_info)
+      : shared_prim(_shared_prim),
+        basis_set_specs(_basis_set_specs),
+        prim_neighbor_list(_prim_neighbor_list),
+        clex_basis_info(_clex_basis_info) {}
+
+  /// Gets called by `for_all_orbits`
+  template <typename OrbitVecType>
+  void operator()(OrbitVecType const &orbits) const {
+    _make_neighborhood_info(orbits);
+    _make_basis_function_info(orbits);
+  }
+
+  std::shared_ptr<Structure const> shared_prim;
+  ClexBasisSpecs basis_set_specs;
+  PrimNeighborList &prim_neighbor_list;
+  ClexBasisInfo &clex_basis_info;
+
+ private:
+  template <typename OrbitVecType>
+  void _make_neighborhood_info(OrbitVecType const &orbits) const {
+    // construct neighborhood and "flower" function info (point corr)
+    auto site_dependency_neighborhoods =
+        make_site_dependency_neighborhoods(orbits.begin(), orbits.end());
+    Index neighborhood_size = 0;
+    Index n_point_corr = site_dependency_neighborhoods.size();
+    for (auto const &neighborhood : site_dependency_neighborhoods) {
+      Index key_index = prim_neighbor_list.neighbor_index(neighborhood.first);
+      n_point_corr = max(key_index + 1, n_point_corr);
+      for (auto const &unitcellcoord : neighborhood.second) {
+        Index neighbor_index = prim_neighbor_list.neighbor_index(unitcellcoord);
+        neighborhood_size = max(neighbor_index + 1, neighborhood_size);
+      }
+    }
+    clex_basis_info.site_dependency_neighborhoods =
+        site_dependency_neighborhoods;
+    clex_basis_info.neighborhood_size = neighborhood_size;
+    clex_basis_info.n_point_corr = n_point_corr;
+  }
+
+  template <typename OrbitVecType>
+  void _make_basis_function_info(OrbitVecType const &orbits) const {
+    // construct ClexBasis
+    ParsingDictionary<DoFType::Traits> const *dof_dict =
+        &DoFType::traits_dict();
+    ClexBasis clex_basis{shared_prim, basis_set_specs, dof_dict};
+    clex_basis.generate(orbits.begin(), orbits.end());
+
+    // collect basis function info
+    Index orbit_index = 0;
+    Index function_index = 0;
+    for (auto const &orbit : orbits) {
+      std::vector<Index> invariant_group_indices;
+      for (SymOp const &op : orbit.equivalence_map()[0]) {
+        invariant_group_indices.push_back(op.index());
+      }
+
+      BasisSet const &bset_prototype = clex_basis.bset_orbit(orbit_index)[0];
+      for (Index i = 0; i < bset_prototype.size(); ++i) {
+        clex_basis_info.basis_function_info.emplace_back(
+            orbit_index, function_index, orbit.prototype(), orbit.size(),
+            invariant_group_indices);
+        function_index++;
+      }
+      orbit_index++;
+    }
+  }
+};
+
+}  // namespace
+
+/// Make ClexBasisInfo
+ClexBasisInfo make_clex_basis_info(
+    std::shared_ptr<Structure const> const &shared_prim,
+    ClexBasisSpecs const &basis_set_specs,
+    PrimNeighborList &prim_neighbor_list) {
+  ClexBasisInfo clex_basis_info;
+  MakeClexBasisInfo f{shared_prim, basis_set_specs, prim_neighbor_list,
+                      clex_basis_info};
+  for_all_orbits(*basis_set_specs.cluster_specs, log(), f);
+  return clex_basis_info;
+}
+}  // namespace CASM

--- a/src/casm/clex/ConfigCorrelations.cc
+++ b/src/casm/clex/ConfigCorrelations.cc
@@ -1,0 +1,307 @@
+#include "casm/clex/ConfigCorrelations.hh"
+
+#include "casm/clex/ClexParamPack.hh"
+#include "casm/clex/Clexulator.hh"
+#include "casm/clex/Configuration.hh"
+#include "casm/clex/Supercell.hh"
+#include "casm/crystallography/Coordinate.hh"
+#include "casm/crystallography/Structure.hh"
+
+namespace CASM {
+
+/// \brief Returns correlations using 'clexulator'. Supercell needs a correctly
+/// populated neighbor list.
+Eigen::VectorXd correlations(const ConfigDoF &configdof, const Supercell &scel,
+                             Clexulator const &clexulator) {
+  // Size of the supercell will be used for normalizing correlations to a per
+  // primitive cell value
+  int scel_vol = scel.volume();
+
+  Eigen::VectorXd correlations = Eigen::VectorXd::Zero(clexulator.corr_size());
+
+  // Inform Clexulator of the bitstring
+
+  // Holds contribution to global correlations from a particular neighborhood
+  Eigen::VectorXd tcorr = correlations;
+  // std::vector<double> corr(clexulator.corr_size(), 0.0);
+
+  for (int v = 0; v < scel_vol; v++) {
+    // Fill up contributions
+    clexulator.calc_global_corr_contribution(
+        configdof, scel.nlist().sites(v).data(), end_ptr(scel.nlist().sites(v)),
+        tcorr.data(), end_ptr(tcorr));
+
+    correlations += tcorr;
+  }
+
+  correlations /= (double)scel_vol;
+
+  return correlations;
+}
+
+/// \brief Returns correlations using 'clexulator'.
+Eigen::VectorXd correlations(const Configuration &config,
+                             Clexulator const &clexulator) {
+  return correlations(config.configdof(), config.supercell(), clexulator);
+}
+
+/// Returns correlation contribution from a single unit cell, not normalized.
+///
+/// Supercell needs a correctly populated neighbor list.
+Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
+                                  const ConfigDoF &configdof,
+                                  const Supercell &scel,
+                                  Clexulator const &clexulator) {
+  if (linear_unitcell_index >= scel.volume()) {
+    std::stringstream msg;
+    msg << "Error in point_corr: linear_unitcell_index out of range ("
+        << linear_unitcell_index << " >= " << scel.volume() << ")";
+    throw std::runtime_error(msg.str());
+  }
+  Eigen::VectorXd correlations = Eigen::VectorXd::Zero(clexulator.corr_size());
+
+  auto const &unitcell_nlist = scel.nlist().sites(linear_unitcell_index);
+  clexulator.calc_global_corr_contribution(
+      configdof, unitcell_nlist.data(), end_ptr(unitcell_nlist),
+      correlations.data(), end_ptr(correlations));
+
+  return correlations;
+}
+
+/// \brief Returns correlations using 'clexulator'.
+Eigen::VectorXd corr_contribution(Index linear_unitcell_index,
+                                  const Configuration &config,
+                                  Clexulator const &clexulator) {
+  return corr_contribution(linear_unitcell_index, config.configdof(),
+                           config.supercell(), clexulator);
+}
+
+/// Returns correlation contributions from all unit cells, not normalized.
+Eigen::MatrixXd all_corr_contribution(const Configuration &config,
+                                      Clexulator const &clexulator) {
+  Eigen::MatrixXd corr(config.supercell().volume(), clexulator.corr_size());
+  for (Index i = 0; i < config.supercell().volume(); i++) {
+    corr.row(i) = corr_contribution(i, config, clexulator);
+  }
+  return corr;
+}
+
+/// \brief Returns point correlations from a single site, normalized by cluster
+/// orbit size
+Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
+                           const ConfigDoF &configdof, const Supercell &scel,
+                           Clexulator const &clexulator) {
+  if (linear_unitcell_index >= scel.volume()) {
+    std::stringstream msg;
+    msg << "Error in point_corr: linear_unitcell_index out of range ("
+        << linear_unitcell_index << " >= " << scel.volume() << ")";
+    throw std::runtime_error(msg.str());
+  }
+
+  Eigen::VectorXd correlations = Eigen::VectorXd::Zero(clexulator.corr_size());
+
+  auto const &unitcell_nlist = scel.nlist().sites(linear_unitcell_index);
+  if (neighbor_index >= clexulator.n_point_corr()) {
+    std::stringstream msg;
+    msg << "Error in point_corr: neighbor_index out of range ("
+        << neighbor_index << " >= " << clexulator.n_point_corr() << ")";
+    throw std::runtime_error(msg.str());
+  }
+  clexulator.calc_point_corr(configdof, unitcell_nlist.data(),
+                             end_ptr(unitcell_nlist), neighbor_index,
+                             correlations.data(), end_ptr(correlations));
+
+  return correlations;
+}
+
+/// \brief Returns point correlations from a single site, normalized by cluster
+/// orbit size
+Eigen::VectorXd point_corr(Index linear_unitcell_index, Index neighbor_index,
+                           const Configuration &config,
+                           Clexulator const &clexulator) {
+  return point_corr(linear_unitcell_index, neighbor_index, config.configdof(),
+                    config.supercell(), clexulator);
+}
+
+/// \brief Returns point correlations from all sites, normalized by cluster
+/// orbit size
+Eigen::MatrixXd all_point_corr(const Configuration &config,
+                               Clexulator const &clexulator) {
+  Index n_rows = config.supercell().volume() * clexulator.n_point_corr();
+  Eigen::MatrixXd corr(n_rows, clexulator.corr_size());
+  Index l = 0;
+  for (Index j = 0; j < clexulator.n_point_corr(); j++) {
+    for (Index i = 0; i < config.supercell().volume(); i++) {
+      corr.row(l) = point_corr(i, j, config, clexulator);
+      ++l;
+    }
+  }
+  return corr;
+}
+
+/// Return a vector of xtal::Coordinate for each row in `all_point_corr`
+std::vector<xtal::UnitCellCoord> make_all_point_corr_unitcellcoord(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist) {
+  // from the input:
+  auto f = sym_info.unitcellcoord_index_converter();
+  Index volume = sym_info.superlattice().size();
+
+  std::vector<xtal::UnitCellCoord> result;
+  for (Index neighbor_index = 0; neighbor_index < n_point_corr;
+       neighbor_index++) {
+    for (Index unitcell_index = 0; unitcell_index < volume; unitcell_index++) {
+      auto const &neighbor_list = scel_nlist.sites(unitcell_index);
+      Index linear_site_index = neighbor_list[neighbor_index];
+      result.push_back(f(linear_site_index));
+    }
+  }
+  return result;
+}
+
+/// Return coordinates (xtal::Coordinate) for each row in `all_point_corr`
+///
+/// - Coordinates are referenced to the supercell lattice
+std::vector<xtal::Coordinate> make_all_point_corr_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist) {
+  std::vector<xtal::UnitCellCoord> uccoords = make_all_point_corr_unitcellcoord(
+      n_point_corr, prim, sym_info, scel_nlist);
+
+  xtal::Lattice const &supercell_lattice = sym_info.supercell_lattice();
+
+  std::vector<xtal::Coordinate> result;
+  for (xtal::UnitCellCoord const &uccoord : uccoords) {
+    xtal::Coordinate coord = uccoord.coordinate(prim);
+    coord.set_lattice(supercell_lattice, CART);
+    result.push_back(coord);
+  }
+  return result;
+}
+
+/// Return Cartesian coordinates (as rows) for each row in `all_point_corr`
+Eigen::MatrixXd make_all_point_corr_cart_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist) {
+  std::vector<xtal::Coordinate> coords =
+      make_all_point_corr_coordinates(n_point_corr, prim, sym_info, scel_nlist);
+  Eigen::MatrixXd result = Eigen::MatrixXd::Zero(coords.size(), 3);
+  Index l = 0;
+  for (xtal::Coordinate const &coord : coords) {
+    result.row(l) = coord.const_cart();
+    l++;
+  }
+  return result;
+}
+
+/// Return fractional coordinates (as rows) for each row in `all_point_corr`
+///
+/// - Fractional coordinates are in terms of the supercell lattice vectors
+Eigen::MatrixXd make_all_point_corr_frac_coordinates(
+    Index n_point_corr, xtal::BasicStructure const &prim,
+    SupercellSymInfo const &sym_info, SuperNeighborList const &scel_nlist) {
+  std::vector<xtal::Coordinate> coords =
+      make_all_point_corr_coordinates(n_point_corr, prim, sym_info, scel_nlist);
+  Eigen::MatrixXd result = Eigen::MatrixXd::Zero(coords.size(), 3);
+  Index l = 0;
+  for (xtal::Coordinate coord : coords) {
+    result.row(l) = coord.const_frac();
+    l++;
+  }
+  return result;
+}
+
+/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
+/// 'dof_type'
+Eigen::MatrixXd gradcorrelations(const ConfigDoF &configdof,
+                                 const Supercell &scel,
+                                 Clexulator const &clexulator, DoFKey &key) {
+  ClexParamKey paramkey;
+  ClexParamKey corr_key(clexulator.param_pack().key("corr"));
+  ClexParamKey dof_key;
+  if (key == "occ") {
+    paramkey = clexulator.param_pack().key("diff/corr/" + key + "_site_func");
+    dof_key = clexulator.param_pack().key("occ_site_func");
+  } else {
+    paramkey = clexulator.param_pack().key("diff/corr/" + key + "_var");
+    dof_key = clexulator.param_pack().key(key + "_var");
+  }
+
+  std::string em_corr, em_dof;
+  em_corr = clexulator.param_pack().eval_mode(corr_key);
+  em_dof = clexulator.param_pack().eval_mode(dof_key);
+
+  // this const_cast is not great...
+  // but it seems like the only place passing const Clexulator is a problem and
+  // it is not actually changing clexulator before/after this function
+  const_cast<Clexulator &>(clexulator)
+      .param_pack()
+      .set_eval_mode(corr_key, "DIFF");
+  const_cast<Clexulator &>(clexulator)
+      .param_pack()
+      .set_eval_mode(dof_key, "DIFF");
+
+  Eigen::MatrixXd gcorr;
+  Index scel_vol = scel.volume();
+  if (DoF::BasicTraits(key).global()) {
+    Eigen::MatrixXd gcorr_func = configdof.global_dof(key).values();
+    gcorr.setZero(gcorr_func.size(), clexulator.corr_size());
+    // Holds contribution to global correlations from a particular neighborhood
+
+    // std::vector<double> corr(clexulator.corr_size(), 0.0);
+    for (int v = 0; v < scel_vol; v++) {
+      // Fill up contributions
+      clexulator.calc_global_corr_contribution(configdof,
+                                               scel.nlist().sites(v).data(),
+                                               end_ptr(scel.nlist().sites(v)));
+
+      for (Index c = 0; c < clexulator.corr_size(); ++c)
+        gcorr.col(c) += clexulator.param_pack().read(paramkey(c));
+    }
+  } else {
+    Eigen::MatrixXd gcorr_func;
+    gcorr.setZero(configdof.local_dof(key).values().size(),
+                  clexulator.corr_size());
+    // Holds contribution to global correlations from a particular neighborhood
+    Index l;
+    for (int v = 0; v < scel_vol; v++) {
+      // Fill up contributions
+      clexulator.calc_global_corr_contribution(configdof,
+                                               scel.nlist().sites(v).data(),
+                                               end_ptr(scel.nlist().sites(v)));
+
+      for (Index c = 0; c < clexulator.corr_size(); ++c) {
+        gcorr_func = clexulator.param_pack().read(paramkey(c));
+
+        for (Index n = 0; n < scel.nlist().sites(v).size(); ++n) {
+          l = scel.nlist().sites(v)[n];
+          // for(Index i=0; i<gcorr_func.cols(); ++i){
+          gcorr.block(l * gcorr_func.rows(), c, gcorr_func.rows(), 1) +=
+              gcorr_func.col(n);
+          // std::cout << "Block: (" << l * gcorr_func.rows() << ", " << c << ",
+          // " << gcorr_func.rows() << ", " << 1 << ") += " <<
+          // gcorr_func.col(n).transpose() << "\n";
+          //}
+        }
+      }
+    }
+  }
+  const_cast<Clexulator &>(clexulator)
+      .param_pack()
+      .set_eval_mode(corr_key, em_corr);
+  const_cast<Clexulator &>(clexulator)
+      .param_pack()
+      .set_eval_mode(dof_key, em_dof);
+
+  return gcorr;
+}
+
+/// \brief Returns gradient correlations using 'clexulator', with respect to DoF
+/// 'dof_type'
+Eigen::MatrixXd gradcorrelations(const Configuration &config,
+                                 Clexulator const &clexulator, DoFKey &key) {
+  return gradcorrelations(config.configdof(), config.supercell(), clexulator,
+                          key);
+}
+
+}  // namespace CASM

--- a/src/casm/clex/PrimClex.cc
+++ b/src/casm/clex/PrimClex.cc
@@ -470,19 +470,15 @@ struct WriteBasisSetDataImpl {
     OrbitPrinterOptions orbit_printer_options;
     orbit_printer_options.print_invariant_group = true;
     ProtoSitesPrinter sites_printer{orbit_printer_options};
-    write_clust(orbits.begin(), orbits.end(), clust_json, sites_printer,
-                basis_set_specs_json);
+    write_clust(orbits.begin(), orbits.end(), clust_json, sites_printer);
+    clust_json["bspecs"] = basis_set_specs_json;
     clust_json.write(clust_json_path);
 
     // write basis
     fs::path basis_json_path = dir.basis(basis_set_name);
     jsonParser basis_json;
-    write_site_basis_funcs(shared_prim, clex_basis, basis_json);
-    bool align = false;
-    ProtoFuncsPrinter funcs_printer{clex_basis, shared_prim->shared_structure(),
-                                    align, orbit_printer_options};
-    write_clust(orbits.begin(), orbits.end(), basis_json, funcs_printer,
-                basis_set_specs_json);
+    write_clex_basis(clex_basis, orbits, basis_json);
+    basis_json["bspecs"] = basis_set_specs_json;
     basis_json.write(basis_json_path);
 
     // write source code

--- a/src/casm/clex/SupercellIO.cc
+++ b/src/casm/clex/SupercellIO.cc
@@ -348,6 +348,13 @@ VectorXdAttributeDictionary<Supercell> make_vectorxd_dictionary<Supercell>() {
 }
 
 template <>
+MatrixXdAttributeDictionary<Supercell> make_matrixxd_dictionary<Supercell>() {
+  using namespace ScelIO;
+  MatrixXdAttributeDictionary<Supercell> dict;
+  return dict;
+}
+
+template <>
 DataFormatterDictionary<Supercell, BaseValueFormatter<jsonParser, Supercell>>
 make_json_dictionary<Supercell>() {
   return DataFormatterDictionary<Supercell,

--- a/src/casm/monte_carlo/canonical/Canonical.cc
+++ b/src/casm/monte_carlo/canonical/Canonical.cc
@@ -1,6 +1,7 @@
 
 #include "casm/monte_carlo/canonical/Canonical.hh"
 
+#include "casm/clex/ConfigCorrelations.hh"
 #include "casm/clex/FillSupercell.hh"
 #include "casm/database/ConfigDatabase.hh"
 #include "casm/misc/CASM_Eigen_math.hh"

--- a/src/casm/monte_carlo/grand_canonical/GrandCanonical.cc
+++ b/src/casm/monte_carlo/grand_canonical/GrandCanonical.cc
@@ -2,6 +2,7 @@
 #include "casm/monte_carlo/grand_canonical/GrandCanonical.hh"
 
 #include "casm/basis_set/DoF.hh"
+#include "casm/clex/ConfigCorrelations.hh"
 #include "casm/clex/FillSupercell.hh"
 #include "casm/clex/Norm.hh"
 #include "casm/clex/PrimClex.hh"

--- a/src/casm/symmetry/io/data/SupercellSymInfo_data_io.cc
+++ b/src/casm/symmetry/io/data/SupercellSymInfo_data_io.cc
@@ -104,10 +104,10 @@ SupercellSymInfoFormatter<double> supercell_volume() {
 SupercellSymInfoFormatter<jsonParser> unitcells() {
   return SupercellSymInfoFormatter<jsonParser>(
       "unitcells",
-      "Integer coordinates of unit cells in the supercell. The order "
-      "corresponds to the both the linear order of site degree of freedom "
-      "values within one sublattice of a configuration, and the order in which "
-      "translational symmetry operations are applied.",
+      "Integer coordinates of unit cells in the supercell. The order is used "
+      "to determine the linear order of sites and site degrees of freedom "
+      "values within one sublattice of a superstructure or configuration, and "
+      "the order in which translational symmetry operations are applied.",
       [](SupercellSymInfo const &supercell_sym_info) -> jsonParser {
         jsonParser json;
         to_json(xtal::make_lattice_points(
@@ -122,7 +122,10 @@ SupercellSymInfoFormatter<jsonParser> integral_site_coordinates() {
       "integral_site_coordinates",
       "Integer coordinates `(b, i, j, k)` of sites in the supercell, where `b` "
       "is the sublattice index of the site, and `(i,j,k)` are the integral "
-      "coordinates of the unit cell containing the site.",
+      "coordinates of the unit cell containing the site. The site order is "
+      "determined by `linear_site_index = linear_unitcell_index + "
+      "supercell_volume * sublattice_index`, where `linear_unitcell_index` is "
+      "an index into the `unitcells` list.",
       [](SupercellSymInfo const &supercell_sym_info) -> jsonParser {
         jsonParser json = jsonParser::array();
         auto f = supercell_sym_info.unitcellcoord_index_converter();

--- a/tests/unit/clex/OccClexulator_test.cpp
+++ b/tests/unit/clex/OccClexulator_test.cpp
@@ -1,9 +1,12 @@
 #include "ProjectBaseTest.hh"
 #include "casm/casm_io/Log.hh"
+#include "casm/clex/ClexBasisInfo.hh"
 #include "casm/clex/Clexulator.hh"
+#include "casm/clex/ConfigCorrelations.hh"
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/PrimClex_impl.hh"
 #include "casm/clex/Supercell.hh"
+#include "casm/clex/io/ProtoFuncsPrinter_impl.hh"
 #include "casm/clex/io/stream/ClexBasis_stream_io.hh"
 #include "crystallography/TestStructures.hh"
 #include "gtest/gtest.h"
@@ -18,11 +21,17 @@ Eigen::Matrix3l _fcc_conventional_transf_mat() {
 }
 }  // namespace
 
-class OccClexulatorTest : public test::ProjectBaseTest {
+/// Assert relations between different correlation calculating methods
+void assert_correlations_equivalence(PrimClex const &primclex,
+                                     std::string const &basis_set_name,
+                                     Configuration const &configuration,
+                                     Clexulator const &clexulator);
+
+class OccClexulatorFCCTest : public test::ProjectBaseTest {
  protected:
   static std::string clex_basis_specs_str();
 
-  OccClexulatorTest()
+  OccClexulatorFCCTest()
       : test::ProjectBaseTest(test::FCC_ternary_prim(), "OccClexulatorTest",
                               jsonParser::parse(clex_basis_specs_str())),
         shared_supercell(std::make_shared<CASM::Supercell>(
@@ -36,7 +45,146 @@ class OccClexulatorTest : public test::ProjectBaseTest {
   std::shared_ptr<CASM::Supercell> shared_supercell;
 };
 
-std::string OccClexulatorTest::clex_basis_specs_str() {
+TEST_F(OccClexulatorFCCTest, UseClexulator) {
+  // Zeros configuration, conventional FCC unit cell
+  CASM::Configuration configuration{shared_supercell};
+
+  // Check configuration
+  EXPECT_EQ(configuration.size(), 4);
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  bool align = false;
+  print_basis_functions(log(), *primclex_ptr, basis_set_name, align);
+
+  // Check clexulator
+  EXPECT_EQ(clexulator.name(), "OccClexulatorTest_Clexulator");
+  EXPECT_EQ(clexulator.nlist_size(), 176);
+  EXPECT_EQ(clexulator.corr_size(), 75);
+  EXPECT_EQ(clexulator.neighborhood().size(), 75);
+
+  Eigen::VectorXd corr = correlations(configuration, clexulator);
+  EXPECT_EQ(corr.size(), 75);
+}
+
+TEST_F(OccClexulatorFCCTest, CorrelationsTest) {
+  // Ones configuration, conventional FCC unit cell
+  CASM::Configuration configuration{shared_supercell};
+  configuration.set_occ(0, 1);
+  configuration.set_occ(1, 1);
+  configuration.set_occ(2, 1);
+  configuration.set_occ(3, 1);
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  assert_correlations_equivalence(*primclex_ptr, basis_set_name, configuration,
+                                  clexulator);
+}
+
+class OccClexulatorZrOTest : public test::ProjectBaseTest {
+ protected:
+  static std::string clex_basis_specs_str();
+
+  OccClexulatorZrOTest()
+      : test::ProjectBaseTest(test::ZrO_prim(), "OccClexulatorZrOTest",
+                              jsonParser::parse(clex_basis_specs_str())),
+        shared_supercell(std::make_shared<CASM::Supercell>(
+            shared_prim, Eigen::Matrix3l::Identity())) {
+    this->write_basis_set_data();
+    this->make_clexulator();
+    shared_supercell->set_primclex(primclex_ptr.get());
+  }
+
+  // conventional ZrO unit cell
+  std::shared_ptr<CASM::Supercell> shared_supercell;
+};
+
+TEST_F(OccClexulatorZrOTest, UseClexulator) {
+  // Zeros configuration, single unit cell
+  CASM::Configuration configuration{shared_supercell};
+
+  // Check configuration
+  EXPECT_EQ(configuration.size(), 4);
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  bool align = false;
+  print_basis_functions(log(), *primclex_ptr, basis_set_name, align);
+
+  // Check clexulator
+  EXPECT_EQ(clexulator.name(), "OccClexulatorZrOTest_Clexulator");
+  EXPECT_EQ(clexulator.nlist_size(), 53);
+  EXPECT_EQ(clexulator.corr_size(), 16);
+  EXPECT_EQ(clexulator.neighborhood().size(), 27);
+
+  Eigen::VectorXd corr = correlations(configuration, clexulator);
+  EXPECT_EQ(corr.size(), 16);
+}
+
+TEST_F(OccClexulatorZrOTest, CorrelationsTest) {
+  // Configuration w/ 1 Va, 1 O, single unit cell
+  CASM::Configuration configuration{shared_supercell};
+  configuration.set_occ(2, 1);  // O
+  configuration.set_occ(3, 0);  // Va
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  assert_correlations_equivalence(*primclex_ptr, basis_set_name, configuration,
+                                  clexulator);
+}
+
+class LocalOccClexulatorZrOTest : public test::ProjectBaseTest {
+ protected:
+  static std::string clex_basis_specs_str();
+
+  LocalOccClexulatorZrOTest()
+      : test::ProjectBaseTest(test::ZrO_prim(), "LocalOccClexulatorZrOTest",
+                              jsonParser::parse(clex_basis_specs_str())),
+        shared_supercell(std::make_shared<CASM::Supercell>(
+            shared_prim, Eigen::Matrix3l::Identity() * 6)) {
+    this->write_basis_set_data();
+    this->make_clexulator();
+    shared_supercell->set_primclex(primclex_ptr.get());
+  }
+
+  // conventional ZrO unit cell
+  std::shared_ptr<CASM::Supercell> shared_supercell;
+};
+
+TEST_F(LocalOccClexulatorZrOTest, UseClexulator) {
+  // Zeros configuration, 6x6x6 supercell
+  CASM::Configuration configuration{shared_supercell};
+
+  // Check configuration
+  EXPECT_EQ(configuration.size(), 4 * 216);
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  bool align = false;
+  print_basis_functions(log(), *primclex_ptr, basis_set_name, align);
+
+  // Check clexulator
+  EXPECT_EQ(clexulator.name(), "LocalOccClexulatorZrOTest_Clexulator");
+  EXPECT_EQ(clexulator.nlist_size(), 53);
+  EXPECT_EQ(clexulator.corr_size(), 33);
+  EXPECT_EQ(clexulator.neighborhood().size(), 26);
+
+  Eigen::VectorXd corr = correlations(configuration, clexulator);
+  EXPECT_EQ(corr.size(), 33);
+}
+
+TEST_F(LocalOccClexulatorZrOTest, CorrelationsTest) {
+  // Configuration w/ 1 O, 6x6x6 supercell
+  CASM::Configuration configuration{shared_supercell};
+  configuration.set_occ(2 * 216, 1);  // O
+
+  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+
+  assert_correlations_equivalence(*primclex_ptr, basis_set_name, configuration,
+                                  clexulator);
+}
+
+std::string OccClexulatorFCCTest::clex_basis_specs_str() {
   return R"({
 "basis_function_specs" : {
 "dof_specs": {
@@ -79,24 +227,116 @@ std::string OccClexulatorTest::clex_basis_specs_str() {
 })";
 }
 
-TEST_F(OccClexulatorTest, UseClexulator) {
-  // Zeros configuration, conventional FCC unit cell
-  CASM::Configuration configuration{shared_supercell};
+std::string OccClexulatorZrOTest::clex_basis_specs_str() {
+  return R"({
+"basis_function_specs" : {
+"dof_specs": {
+  "occ": {
+    "site_basis_functions" : "occupation"
+  }
+}
+},
+"cluster_specs": {
+"method": "periodic_max_length",
+"params": {
+  "orbit_branch_specs" : {
+    "2" : {"max_length" : 6.01},
+    "3" : {"max_length" : 4.14},
+    "4" : {"max_length" : 4.14}
+  }
+}
+}
+})";
+}
 
-  // Check configuration
-  EXPECT_EQ(configuration.size(), 4);
+std::string LocalOccClexulatorZrOTest::clex_basis_specs_str() {
+  return R"({
+"basis_function_specs" : {
+"dof_specs": {
+  "occ": {
+    "site_basis_functions" : "occupation"
+  }
+}
+},
+"cluster_specs": {
+"method": "local_max_length",
+"params": {
+  "generating_group" : [ 0, 3, 4, 9, 10, 11, 12, 13, 14, 15, 21, 22 ],
+  "phenomenal" : {
+    "coordinate_mode" : "Integral",
+    "sites" : [
+      [ 2, 0, 0, 0 ],
+      [ 3, 0, 0, 0 ]
+    ]
+  },
+  "orbit_branch_specs" : {
+    "1" : {"cutoff_radius": 6.01},
+    "2" : {"cutoff_radius": 6.01, "max_length" : 6.01}
+  }
+}
+}
+})";
+}
 
-  Clexulator clexulator = primclex_ptr->clexulator(basis_set_name);
+/// Assert relations between different correlation calculating methods
+///
+/// Assert relations between:
+/// - correlations(configuration, clexulator)
+/// - all_corr_contribution(configuration, clexulator)
+/// - all_point_corr(configuration, clexulator)
+void assert_correlations_equivalence(PrimClex const &primclex,
+                                     std::string const &basis_set_name,
+                                     Configuration const &configuration,
+                                     Clexulator const &clexulator) {
+  std::shared_ptr<Structure const> const &shared_prim = primclex.shared_prim();
+  ClexBasisSpecs const &basis_set_specs =
+      primclex.basis_set_specs(basis_set_name);
 
-  bool align = false;
-  print_basis_functions(log(), *primclex_ptr, basis_set_name, align);
+  ClexBasisInfo clex_basis_info =
+      make_clex_basis_info(shared_prim, basis_set_specs, primclex.nlist());
+  ASSERT_EQ(clex_basis_info.basis_function_info.size(), clexulator.corr_size());
 
-  // Check clexulator
-  EXPECT_EQ(clexulator.name(), "OccClexulatorTest_Clexulator");
-  EXPECT_EQ(clexulator.nlist_size(), 176);
-  EXPECT_EQ(clexulator.corr_size(), 75);
-  EXPECT_EQ(clexulator.neighborhood().size(), 75);
+  // jsonParser basis_json;
+  // write_clex_basis(shared_prim, basis_set_specs, basis_json);
+  // std::cout << "basis: \n" << basis_json << std::endl;
 
-  Eigen::VectorXd corr = correlations(configuration, clexulator);
-  EXPECT_EQ(corr.size(), 75);
+  Eigen::VectorXd C_corr = correlations(configuration, clexulator);
+
+  Index volume = configuration.supercell().volume();
+
+  Eigen::VectorXd sum;
+  Eigen::VectorXd mean;
+
+  // confirm mean over unit cells of all_corr_contributions = correlations
+  Eigen::MatrixXd C_all_corr_contribution =
+      all_corr_contribution(configuration, clexulator);
+  ASSERT_EQ(C_all_corr_contribution.rows(), volume);
+  ASSERT_EQ(C_all_corr_contribution.cols(), clexulator.corr_size());
+  sum = Eigen::VectorXd::Zero(clexulator.corr_size());
+  for (Index i = 0; i < C_all_corr_contribution.rows(); ++i) {
+    sum += C_all_corr_contribution.row(i);
+  }
+  mean = sum / (1.0 * C_all_corr_contribution.rows());
+  ASSERT_TRUE(almost_equal(mean, C_corr));
+
+  // confirm:
+  // - all_point_corr for null cluster is 0.0
+  // - mean over unit cells of all_point_corr / cluster size = correlations
+  Eigen::MatrixXd C_all_point_corr = all_point_corr(configuration, clexulator);
+  ASSERT_EQ(C_all_point_corr.rows(), clex_basis_info.n_point_corr * volume);
+  ASSERT_EQ(C_all_point_corr.cols(), clexulator.corr_size());
+  sum = Eigen::VectorXd::Zero(clexulator.corr_size());
+  for (Index i = 0; i < C_all_point_corr.rows(); ++i) {
+    sum += C_all_point_corr.row(i);
+  }
+  mean = sum / (1.0 * C_all_point_corr.rows() / clex_basis_info.n_point_corr);
+  for (Index j = 0; j < clexulator.corr_size(); ++j) {
+    double cluster_size =
+        clex_basis_info.basis_function_info[j].prototype.size();
+    if (j == 0) {
+      EXPECT_TRUE(almost_equal(mean(j), 0.));
+    } else {
+      EXPECT_TRUE(almost_equal(mean(j) / cluster_size, C_corr(j)));
+    }
+  }
 }

--- a/tests/unit/clex/OccStrainClexulator_test.cpp
+++ b/tests/unit/clex/OccStrainClexulator_test.cpp
@@ -1,6 +1,7 @@
 #include "ProjectBaseTest.hh"
 #include "casm/casm_io/Log.hh"
 #include "casm/clex/Clexulator.hh"
+#include "casm/clex/ConfigCorrelations.hh"
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/PrimClex_impl.hh"
 #include "casm/clex/Supercell.hh"

--- a/tests/unit/clex/StrainClexulator_test.cpp
+++ b/tests/unit/clex/StrainClexulator_test.cpp
@@ -1,6 +1,7 @@
 #include "ProjectBaseTest.hh"
 #include "casm/casm_io/Log.hh"
 #include "casm/clex/Clexulator.hh"
+#include "casm/clex/ConfigCorrelations.hh"
 #include "casm/clex/Configuration.hh"
 #include "casm/clex/PrimClex_impl.hh"
 #include "casm/clex/Supercell.hh"


### PR DESCRIPTION
- Fix `point_corr` output bug -- was giving `corr_contribution`
- Improves correlations output with `all_point_corr` and `all_corr_contribution` queries
- Output point corr site coordinates with `all_point_corr_frac_coordinates` and `all_point_corr_cart_coordinates` from `NeighborListInfo`
- Easier collection of ClexBasis info via ClexBasisInfo
- Improved tests of correlation calculations