### PR TITLE
include fix

### DIFF
--- a/include/casm/clex/PrimClex.hh
+++ b/include/casm/clex/PrimClex.hh
@@ -2,6 +2,7 @@
 #define CASM_PrimClex
 
 #include <memory>
+#include <vector>
 
 #include "casm/global/definitions.hh"
 


### PR DESCRIPTION
- Needed to add `#include <vector>` in `PrimClex.hh`. Otherwise it was not compiling on linux with `g++`