### PR TITLE
fixed casm query atomic_deformation, lattice_deformation, struc_score

### DIFF
--- a/src/casm/app/sym/dof_space_analysis.cc
+++ b/src/casm/app/sym/dof_space_analysis.cc
@@ -1,5 +1,7 @@
 #include "casm/app/sym/dof_space_analysis.hh"
 
+#include <optional>
+
 #include "casm/app/io/json_io.hh"
 #include "casm/casm_io/container/json_io.hh"
 #include "casm/casm_io/json/InputParser_impl.hh"

--- a/src/casm/clex/ConfigIOStrucScore.cc
+++ b/src/casm/clex/ConfigIOStrucScore.cc
@@ -117,6 +117,8 @@ bool StrucScore::init(const Configuration &_tmplt) const {
 
   m_strucmapper = notstd::make_unique<StrucMapper>(
       PrimStrucMapCalculator(*m_altprim), m_strain_weight);
+
+  for (Index i=0; i < m_prop_names.size(); i++) _add_rule(std::vector<Index>({i}));
   return true;
 }
 
@@ -167,11 +169,11 @@ Eigen::VectorXd StrucScore::evaluate(const Configuration &_config) const {
   MappingNode const &mapping(*result.begin());
 
   for (Index i = 0; i < m_prop_names.size(); i++) {
-    if (m_prop_names[i] == "basis_score") {
+    if (m_prop_names[i] == "atomic_deformation_cost") {
       result_vec[i] = mapping.atomic_node.cost;
-    } else if (m_prop_names[i] == "lattice_score") {
+    } else if (m_prop_names[i] == "lattice_deformation_cost") {
       result_vec[i] = mapping.lattice_node.cost;
-    } else if (m_prop_names[i] == "total_score") {
+    } else if (m_prop_names[i] == "total_cost") {
       result_vec[i] = mapping.cost;
     }
   }

--- a/src/casm/clex/ConfigIOStrucScore.cc
+++ b/src/casm/clex/ConfigIOStrucScore.cc
@@ -87,7 +87,6 @@ bool StrucScore::parse_args(const std::string &args) {
         splt_vec[i] != "total_score") {
       try {
         _strain_weight = std::stod(splt_vec[i]);
-        m_strain_weight = _strain_weight;
       } catch (...) {
         throw std::runtime_error("Attempted to initialize format tag " +
                                  name() + " with invalid argument '" +
@@ -95,6 +94,9 @@ bool StrucScore::parse_args(const std::string &args) {
                                  "'. Valid arguments are [ basis_score | "
                                  "lattice_score | total_score ]\n");
       }
+      
+      m_strain_weight = _strain_weight;
+
       if (already_initialized &&
           !almost_equal(_strain_weight, m_strain_weight)) {
         for (; pushed_args > 0; pushed_args--) m_prop_names.pop_back();
@@ -119,7 +121,10 @@ bool StrucScore::init(const Configuration &_tmplt) const {
   m_strucmapper = notstd::make_unique<StrucMapper>(
       PrimStrucMapCalculator(*m_altprim), m_strain_weight);
 
-  for (Index i=0; i < m_prop_names.size(); i++) _add_rule(std::vector<Index>({i}));
+  for (Index i=0; i < m_prop_names.size(); i++) {
+    _add_rule(std::vector<Index>({i}));
+  }
+
   return true;
 }
 

--- a/src/casm/clex/ConfigIOStrucScore.cc
+++ b/src/casm/clex/ConfigIOStrucScore.cc
@@ -170,11 +170,11 @@ Eigen::VectorXd StrucScore::evaluate(const Configuration &_config) const {
   MappingNode const &mapping(*result.begin());
 
   for (Index i = 0; i < m_prop_names.size(); i++) {
-    if (m_prop_names[i] == "atomic_deformation_cost") {
+    if (m_prop_names[i] == "basis_score") {
       result_vec[i] = mapping.atomic_node.cost;
-    } else if (m_prop_names[i] == "lattice_deformation_cost") {
+    } else if (m_prop_names[i] == "lattice_score") {
       result_vec[i] = mapping.lattice_node.cost;
-    } else if (m_prop_names[i] == "total_cost") {
+    } else if (m_prop_names[i] == "total_score") {
       result_vec[i] = mapping.cost;
     }
   }

--- a/src/casm/clex/ConfigIOStrucScore.cc
+++ b/src/casm/clex/ConfigIOStrucScore.cc
@@ -87,6 +87,7 @@ bool StrucScore::parse_args(const std::string &args) {
         splt_vec[i] != "total_score") {
       try {
         _strain_weight = std::stod(splt_vec[i]);
+        m_strain_weight = _strain_weight;
       } catch (...) {
         throw std::runtime_error("Attempted to initialize format tag " +
                                  name() + " with invalid argument '" +

--- a/src/casm/clex/Configuration.cc
+++ b/src/casm/clex/Configuration.cc
@@ -881,12 +881,12 @@ double formation_energy_per_species(const Configuration &config) {
 /// \brief Cost function that describes the degree to which basis sites have
 /// relaxed
 double atomic_deformation(const Configuration &_config) {
-  return _config.calc_properties().scalar("atomic_deformation");
+  return _config.calc_properties().scalar("atomic_deformation_cost");
 }
 
 /// \brief Cost function that describes the degree to which lattice has relaxed
 double lattice_deformation(const Configuration &_config) {
-  return _config.calc_properties().scalar("lattice_deformation");
+  return _config.calc_properties().scalar("lattice_deformation_cost");
 }
 
 /// \brief Change in volume due to relaxation, expressed as the ratio V/V_0
@@ -1020,11 +1020,11 @@ bool has_rms_force(const Configuration &_config) {
 }
 
 bool has_atomic_deformation(const Configuration &_config) {
-  return _config.calc_properties().has_scalar("atomic_deformation");
+  return _config.calc_properties().has_scalar("atomic_deformation_cost");
 }
 
 bool has_lattice_deformation(const Configuration &_config) {
-  return _config.calc_properties().has_scalar("lattice_deformation");
+  return _config.calc_properties().has_scalar("lattice_deformation_cost");
 }
 
 bool has_volume_relaxation(const Configuration &_config) {

--- a/tests/unit/clex/data/configIO_data.json
+++ b/tests/unit/clex/data/configIO_data.json
@@ -1,0 +1,11 @@
+{
+"origin":"Test Configuration",
+"init": "Test Configuraiton",
+"to": "Test Configuration",
+"global":{
+    "atomic_deformation_cost":0.001,
+    "lattice_deformation_cost": 0.01
+},
+"site":{
+}
+}


### PR DESCRIPTION
- compilation is failing on linux without `#include <optional>` in `dof_space_analysis.cc`

 `ccasm query -k atomic_deformation lattice_deformation` is returning `unknown` fix:
- In the properties database they are stored as `atomic_deformation_cost` and `lattice_deformation_cost` and when querying it's trying to look for `atomic_deformation` and `lattice_deformation`. Hence the unknown always.

`ccasm query -k struc_score(prim.json, *)` printing empty strings fix:
- In `CASM::StrucScore::init()`, the `_index_rules()` are not being set which is used by `Base1DDatumFormatter::print()` (base class for `VectorXdAttributeDictionary` which is what `StrucScore` is derived from) iterates through nothing printing nothing. I added `_index_rules()` to match with `m_prop_names.size()`.

`ccasm query -k struc_score(prim.json,*, weight)` always uses 0.5 as weight:
- When doing `StrucScore::parse_args` even when `_strain_weight` is found, `m_strain_weight` is not being updated hence resulting in `m_strain_weight` which is set to `0.5` in `StrucScore` constructor.