### PR TITLE
if local_dof_rep is empty; skip sublattice instead of accessing it

### DIFF
--- a/include/casm/clex/ConfigDoFIsEquivalent.hh
+++ b/include/casm/clex/ConfigDoFIsEquivalent.hh
@@ -334,6 +334,12 @@ class Local {
     if (A.factor_group_index() != m_fg_index_A || !m_tmp_valid) {
       for (Index b = 0; b < m_n_sublat; ++b) {
         m_fg_index_A = A.factor_group_index();
+        
+        // check if local dof rep is empty; if empty skip sublattice
+        if (A.local_dof_rep_empty(m_key, b)){
+                continue;
+        }
+
         Eigen::MatrixXd const &M = *(A.local_dof_rep(m_key, b).MatrixXd());
         Index dim = M.cols();
         sublattice_block(m_new_dof_A, b, m_n_vol).topRows(dim) =
@@ -348,6 +354,12 @@ class Local {
     if (B.factor_group_index() != m_fg_index_B || !m_tmp_valid) {
       for (Index b = 0; b < m_n_sublat; ++b) {
         m_fg_index_B = B.factor_group_index();
+
+        // check if local dof rep is empty; if empty skip sublattice
+        if (B.local_dof_rep_empty(m_key, b)){
+            continue;
+        }
+
         Eigen::MatrixXd const &M = *(B.local_dof_rep(m_key, b).MatrixXd());
         Index dim = M.cols();
         sublattice_block(m_new_dof_B, b, m_n_vol).topRows(dim) =

--- a/include/casm/symmetry/PermuteIterator.hh
+++ b/include/casm/symmetry/PermuteIterator.hh
@@ -103,6 +103,9 @@ class PermuteIterator
   /// corresponding to local DoF specified by _key on sublattice b
   SymOpRepresentation const &local_dof_rep(DoFKey const &_key, Index b) const;
 
+  /// Check if local DoF representation is empty
+  bool local_dof_rep_empty(DoFKey const &_key, Index b) const;
+
   /// Returns representation of current operation corresponding to global DoF
   /// specified by _key
   SymOpRepresentation const &global_dof_rep(DoFKey const &_key) const;

--- a/include/casm/symmetry/SymGroupRep.hh
+++ b/include/casm/symmetry/SymGroupRep.hh
@@ -3,6 +3,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 #include "casm/container/multivector.hh"
@@ -227,6 +228,9 @@ class SymGroupRepHandle {  // <-- typedefed as SymGroupRep::RemoteHandle
   /// \param i Index into SymGroup, which may be a subgroup of the
   /// MasterSymGroup
   SymOpRepresentation const *operator[](Index i) const {
+    if (m_group_rep == nullptr){
+        throw std::runtime_error("Error in SymGroupRepHandle: Attempting to use empty SymGroupRepHandle");
+    }
     return m_group_rep->at(m_subgroup_op_inds[i]);
   }
 

--- a/src/casm/app/sym/dof_space_analysis.cc
+++ b/src/casm/app/sym/dof_space_analysis.cc
@@ -1,5 +1,7 @@
 #include "casm/app/sym/dof_space_analysis.hh"
 
+#include <optional>
+
 #include "casm/app/io/json_io.hh"
 #include "casm/casm_io/container/json_io.hh"
 #include "casm/casm_io/json/InputParser_impl.hh"

--- a/src/casm/clex/ConfigDoF.cc
+++ b/src/casm/clex/ConfigDoF.cc
@@ -257,10 +257,15 @@ ConfigDoF &ConfigDoF::apply_sym_no_permute(SymOp const &_op) {
   }
 
   for (auto &dof : m_local_dofs) {
-    for (Index b = 0; b < m_N_sublat; ++b)
-      dof.second.sublat(b) =
+    for (Index b = 0; b < m_N_sublat; ++b){
+        if (dof.second.info()[b].symrep_ID().empty()){
+            continue;
+        }
+
+        dof.second.sublat(b) =
           *(_op.representation(dof.second.info()[b].symrep_ID()).MatrixXd()) *
           dof.second.sublat(b);
+    }
   }
 
   return *this;

--- a/src/casm/clex/ConfigDoF.cc
+++ b/src/casm/clex/ConfigDoF.cc
@@ -214,6 +214,11 @@ ConfigDoF &ConfigDoF::apply_sym(PermuteIterator const &it) {
     Eigen::MatrixXd tmp{init_value};
 
     for (Index b = 0; b < m_N_sublat; ++b) {
+      // if local dof is empty; skip sublattice
+      if (it.local_dof_rep_empty(dof.first, b)){
+          continue;
+      }
+
       Eigen::MatrixXd const &rep = *it.local_dof_rep(dof.first, b).MatrixXd();
       Index rows = rep.rows();
       clexulator::sublattice_block(tmp, b, m_N_vol).topRows(rows) =

--- a/src/casm/clex/ConfigDoFValues.cc
+++ b/src/casm/clex/ConfigDoFValues.cc
@@ -147,10 +147,14 @@ void LocalContinuousConfigDoFValues::from_standard_values(
         << ", received cols=" << _standard_values.cols();
     throw std::runtime_error(msg.str());
   }
-  for (Index b = 0; b < n_sublat(); ++b)
+  for (Index b = 0; b < n_sublat(); ++b){
+    if (info()[b].symrep_ID().empty()){
+        continue;
+    }
     sublat(b).topRows(info()[b].dim()) =
         info()[b].inv_basis() *
         _standard_values.block(0, b * n_vol(), m_vals.rows(), n_vol());
+  }
 }
 
 /// Get local DoF values as standard DoF values

--- a/src/casm/symmetry/PermuteIterator.cc
+++ b/src/casm/symmetry/PermuteIterator.cc
@@ -101,6 +101,14 @@ SymOpRepresentation const &PermuteIterator::local_dof_rep(DoFKey const &_key,
   return *sym_info().local_dof_symreps(_key)[b][factor_group_index()];
 }
 
+/// Check if local dof rep is empty
+bool PermuteIterator::local_dof_rep_empty(DoFKey const &_key, Index b) const{
+   if (sym_info().local_dof_symreps(_key)[b].rep_ptr() == nullptr){
+       return true;
+   }
+   return false;
+}
+
 /// Returns representation of current operation corresponding to global DoF
 /// specified by _key
 SymOpRepresentation const &PermuteIterator::global_dof_rep(


### PR DESCRIPTION
- Added `#include <optional>` in `dof_space_analysis.cc` to make it compilable on linux.
- Added `local_dof_rep_empty(DoFKey const &_key, Index b)` in `PermuteIterator.cc` to check if a particular site doesn't have any sym reps.
- If trying to access an empty rep, an error message will be thrown in `SymGroupRepHandle`
- Wherever looping over sublattices to access `local_dof_rep()`, check initially if `local_dof_rep_empty` and if it is empty skip this sublattice.