### PR TITLE
use axes cols as default max_nonzero

### DIFF
--- a/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
+++ b/src/casm/app/enum/methods/ConfigEnumSiteDoFsInterface.cc
@@ -351,7 +351,7 @@ void parse(InputParser<ConfigEnumSiteDoFsParams> &parser,
   // note that help indicates default==axes.rows(), but that is
   // params.axes.cols()
   parser.optional_else(params.max_nonzero, "max_nonzero",
-                       Index{params.axes.cols()});
+                       Index{axes_params.axes.cols()});
 
   // Throw error if min_nonzero exceeds max_nonzero
   if (params.min_nonzero > params.max_nonzero) {


### PR DESCRIPTION
- As the documentation suggests default `max_nonzero` should be `axes.cols()`
- `params.axes` is set after `parser` reads `max_nonzero`, making `max_nonzero` default value as 0 instead of `axes.cols()`
- Changed `params.axes` to `axes_params.axes` to get `axes` info to fix this.