### PR TITLE
set_required_properties when new-calctype is created

### DIFF
--- a/src/casm/app/settings.cc
+++ b/src/casm/app/settings.cc
@@ -586,6 +586,7 @@ int settings_command(const CommandArgs &args) {
     d.calctype = pair_type(single_input, create);
     d.ref = pair_type("default", create);
     d.eci = pair_type("default", create);
+    d.set.set_required_properties("Configuration",d.calctype.first, {"energy"});
 
     return d.update();
   }


### PR DESCRIPTION
- Whenever a `new-calctype` is created, `set_required_properties` is not being called, causing an error whenever going through the `required_properties` of the `new-calctype`