### PR TITLE
apply atomize after for cmagspin, etc

### DIFF
--- a/include/casm/clex/SimpleStructureTools.hh
+++ b/include/casm/clex/SimpleStructureTools.hh
@@ -6,6 +6,7 @@
 
 #include "casm/crystallography/DoFDecl.hh"
 #include "casm/global/definitions.hh"
+#include "casm/basis_set/DoFTraits.hh"
 
 namespace CASM {
 
@@ -85,6 +86,50 @@ std::vector<std::set<Index> > atom_site_compatibility(
 std::vector<std::set<Index> > mol_site_compatibility(
     xtal::SimpleStructure const &sstruc, Configuration const &_config);
 
+namespace clex_SimpleStructureTools_impl {
+
+/// Class that helps manage which order DoF are applied to a SimpleStructure
+/// when building it from a Configuration. Each TransformDirective applies one
+/// DoF type or "atomizes" molecules (populating SimpleStructure::atom_info from
+/// SimpleStructure::mol_info). It is meant to be stored in a
+/// std::set<TransformDirective> and has a comparison operator and uses
+/// information from AnisoValTraits to appropriately order TransformDirective in
+/// the set. Then they can be applied sequentially (using `transform`) to build
+/// the SimpleStructure.
+class TransformDirective {
+ public:
+  /// \brief consturct from transformation or DoF type name
+  TransformDirective(std::string const &_name);
+
+  /// \brief Name of DoFType or transformation
+  std::string const &name() const { return m_name; }
+
+  /// \brief Compare with _other TransformDirective. Returns true if this
+  /// TransformDirective has precedence
+  bool operator<(TransformDirective const &_other) const;
+
+  /// \brief Applies transformation to _struc using information contained in
+  /// _config
+  void transform(ConfigDoF const &_config,
+                 xtal::BasicStructure const &_reference,
+                 xtal::SimpleStructure &_struc) const;
+
+ private:
+  /// \brief Build m_before object by recursively traversing DoF dependencies
+  void _accumulate_before(std::set<std::string> const &_queue,
+                          std::set<std::string> &_result) const;
+
+  /// \brief Build m_after object by recursively traversing DoF dependencies
+  void _accumulate_after(std::set<std::string> const &_queue,
+                         std::set<std::string> &_result) const;
+
+  std::string m_name;
+  std::set<std::string> m_before;
+  std::set<std::string> m_after;
+
+  DoFType::Traits const *m_traits_ptr;
+};
+}
 }  // namespace CASM
 
 #endif

--- a/src/casm/clex/SimpleStructureTools.cc
+++ b/src/casm/clex/SimpleStructureTools.cc
@@ -125,48 +125,6 @@ std::vector<std::set<Index> > atom_site_compatibility(
 
 namespace clex_SimpleStructureTools_impl {
 
-/// Class that helps manage which order DoF are applied to a SimpleStructure
-/// when building it from a Configuration. Each TransformDirective applies one
-/// DoF type or "atomizes" molecules (populating SimpleStructure::atom_info from
-/// SimpleStructure::mol_info). It is meant to be stored in a
-/// std::set<TransformDirective> and has a comparison operator and uses
-/// information from AnisoValTraits to appropriately order TransformDirective in
-/// the set. Then they can be applied sequentially (using `transform`) to build
-/// the SimpleStructure.
-class TransformDirective {
- public:
-  /// \brief consturct from transformation or DoF type name
-  TransformDirective(std::string const &_name);
-
-  /// \brief Name of DoFType or transformation
-  std::string const &name() const { return m_name; }
-
-  /// \brief Compare with _other TransformDirective. Returns true if this
-  /// TransformDirective has precedence
-  bool operator<(TransformDirective const &_other) const;
-
-  /// \brief Applies transformation to _struc using information contained in
-  /// _config
-  void transform(ConfigDoF const &_config,
-                 xtal::BasicStructure const &_reference,
-                 xtal::SimpleStructure &_struc) const;
-
- private:
-  /// \brief Build m_before object by recursively traversing DoF dependencies
-  void _accumulate_before(std::set<std::string> const &_queue,
-                          std::set<std::string> &_result) const;
-
-  /// \brief Build m_after object by recursively traversing DoF dependencies
-  void _accumulate_after(std::set<std::string> const &_queue,
-                         std::set<std::string> &_result) const;
-
-  std::string m_name;
-  std::set<std::string> m_before;
-  std::set<std::string> m_after;
-
-  DoFType::Traits const *m_traits_ptr;
-};
-
 void _apply_dofs(xtal::SimpleStructure &_sstruc, ConfigDoF const &_config,
                  xtal::BasicStructure const &_reference,
                  std::vector<DoFKey> which_dofs) {

--- a/src/casm/crystallography/AnisoValTraits.cc
+++ b/src/casm/crystallography/AnisoValTraits.cc
@@ -446,7 +446,7 @@ AnisoValTraits AnisoValTraits::strain(std::string const &_prefix) {
 /// - is_default(): false
 AnisoValTraits AnisoValTraits::SOmagspin() {
   return AnisoValTraits("SOmagspin", {"sx", "sy", "sz"}, LOCAL | EXTENSIVE,
-                        AngularMomentumSymRepBuilder(), {}, {"atomize"}, {}, {},
+                        AngularMomentumSymRepBuilder(), {}, {}, {"atomize"}, {},
                         true);
 }
 
@@ -463,7 +463,7 @@ AnisoValTraits AnisoValTraits::SOmagspin() {
 AnisoValTraits AnisoValTraits::SOunitmagspin() {
   return AnisoValTraits(
       "SOunitmagspin", {"sx", "sy", "sz"}, LOCAL | UNIT_LENGTH | EXTENSIVE,
-      AngularMomentumSymRepBuilder(), {}, {"atomize"}, {}, {}, true);
+      AngularMomentumSymRepBuilder(), {}, {}, {"atomize"}, {}, true);
 }
 
 /// \brief Non-collinear magnetic spin, without spin-orbit coupling
@@ -477,7 +477,7 @@ AnisoValTraits AnisoValTraits::SOunitmagspin() {
 /// - is_default(): true
 AnisoValTraits AnisoValTraits::NCmagspin() {
   return AnisoValTraits("NCmagspin", {"sx", "sy", "sz"}, LOCAL | EXTENSIVE,
-                        TimeReversalSymRepBuilder(), {}, {"atomize"}, {}, {},
+                        TimeReversalSymRepBuilder(), {}, {}, {"atomize"}, {},
                         true);
 }
 
@@ -495,7 +495,7 @@ AnisoValTraits AnisoValTraits::NCmagspin() {
 AnisoValTraits AnisoValTraits::NCunitmagspin() {
   return AnisoValTraits(
       "NCunitmagspin", {"sx", "sy", "sz"}, LOCAL | UNIT_LENGTH | EXTENSIVE,
-      TimeReversalSymRepBuilder(), {}, {"atomize"}, {}, {}, true);
+      TimeReversalSymRepBuilder(), {}, {}, {"atomize"}, {}, true);
 }
 
 /// \brief Collinear magnetic spin
@@ -509,7 +509,7 @@ AnisoValTraits AnisoValTraits::NCunitmagspin() {
 /// - is_default(): true
 AnisoValTraits AnisoValTraits::Cmagspin() {
   return AnisoValTraits("Cmagspin", {"m"}, LOCAL | EXTENSIVE,
-                        TimeReversalSymRepBuilder(), {}, {"atomize"}, {}, {},
+                        TimeReversalSymRepBuilder(), {}, {}, {"atomize"}, {},
                         true);
 }
 
@@ -524,7 +524,7 @@ AnisoValTraits AnisoValTraits::Cmagspin() {
 /// - is_default(): true
 AnisoValTraits AnisoValTraits::Cunitmagspin() {
   return AnisoValTraits("Cunitmagspin", {"m"}, LOCAL | UNIT_LENGTH | EXTENSIVE,
-                        TimeReversalSymRepBuilder(), {}, {"atomize"}, {}, {},
+                        TimeReversalSymRepBuilder(), {}, {}, {"atomize"}, {},
                         true);
 }
 

--- a/tests/unit/crystallography/AnisoValTraits_test.cpp
+++ b/tests/unit/crystallography/AnisoValTraits_test.cpp
@@ -1,8 +1,31 @@
 #include "casm/crystallography/AnisoValTraits.hh"
 
+#include "casm/clex/SimpleStructureTools.hh"
 #include "gtest/gtest.h"
 
 using namespace CASM;
+using namespace CASM::clex_SimpleStructureTools_impl;
+
+/// Assert to make sure that when std::set<TransfromDirective> is made with
+/// atomize and an AnisoValTrait (which should be applied before atomize),
+/// AnisoValTrait exists before atomize in the set
+void assert_anisovaltrait_before_atomize(const std::string& anisovaltrait) {
+  std::set<TransformDirective> transform_directives(
+      {TransformDirective("atomize"), TransformDirective(anisovaltrait)});
+  EXPECT_EQ(transform_directives.size(), 2);
+
+  int i = 0;
+  for (const auto& directive : transform_directives) {
+    if (i == 0) {
+      EXPECT_EQ(directive.name(), anisovaltrait);
+    }
+
+    if (i == 1) {
+      EXPECT_EQ(directive.name(), "atomize");
+    }
+    ++i;
+  }
+}
 
 TEST(AnisoValTraitsTest, dOrbitalOccupationConstruction) {
   AnisoValTraits occ = AnisoValTraits::d_orbital_occupation();
@@ -14,4 +37,70 @@ TEST(AnisoValTraitsTest, dOrbitalOccupationSpinPolarizedConstruction) {
   AnisoValTraits occ = AnisoValTraits::d_orbital_occupation_spin_polarized();
   EXPECT_EQ(occ.name(), "dorbitaloccupationspinpolarized") << "Name is wrong!";
   EXPECT_EQ(occ.dim(), 30) << "Not 30-dimensional!";
+}
+
+TEST(AnisoValTraitsTest, Cmagpsin) {
+  AnisoValTraits Cmagpsin = AnisoValTraits::Cmagspin();
+  std::set<std::string> must_apply_after = Cmagpsin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("Cmagspin");
+}
+
+TEST(AnisoValTraitsTest, Cunitmagspin) {
+  AnisoValTraits Cunitmagspin = AnisoValTraits::Cunitmagspin();
+  std::set<std::string> must_apply_after = Cunitmagspin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("Cunitmagspin");
+}
+
+TEST(AnisoValTraitsTest, NCmagpsin) {
+  AnisoValTraits NCmagpsin = AnisoValTraits::NCmagspin();
+  std::set<std::string> must_apply_after = NCmagpsin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("NCmagspin");
+}
+
+TEST(AnisoValTraitsTest, NCunitmagspin) {
+  AnisoValTraits NCunitmagspin = AnisoValTraits::NCunitmagspin();
+  std::set<std::string> must_apply_after = NCunitmagspin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("NCunitmagspin");
+}
+
+TEST(AnisoValTraitsTest, SOmagspin) {
+  AnisoValTraits SOmagspin = AnisoValTraits::NCunitmagspin();
+  std::set<std::string> must_apply_after = SOmagspin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("SOmagspin");
+}
+
+TEST(AnisoValTraitsTest, SOunitmagspin) {
+  AnisoValTraits SOunitmagspin = AnisoValTraits::SOunitmagspin();
+  std::set<std::string> must_apply_after = SOunitmagspin.must_apply_after();
+  EXPECT_EQ(must_apply_after.size(), 1);
+
+  for (const std::string& atomize : must_apply_after) {
+    EXPECT_EQ(atomize, "atomize");
+  }
+  assert_anisovaltrait_before_atomize("SOunitmagspin");
 }


### PR DESCRIPTION
- Moved `TransformDirective` to the header file in order to use in tests, to ensure the order of applying dofs is accurate.
- Changed `atomize` to `must_apply_after` for `Cmagspin`, `SOmagspin`, `NCmagspin` and their `unit` counterparts.
- Added tests to ensure `atomize` exists in `must_apply_after` for the above mentioned `AnisoValTraits` .
- Added tests to ensure when a `std::set<TransformDirective>` is constructed with `TransformDirective("atomize") ` and `TransformDirective(AnisoValTrait)`, `atomize` comes after `AnisoValTrait`