### PR TITLE
magnetic group latex name fix

### DIFF
--- a/src/casm/symmetry/SymGroup.cc
+++ b/src/casm/symmetry/SymGroup.cc
@@ -903,7 +903,7 @@ std::map<std::string, std::string> point_group_info(SymGroup const &g) {
     nonmag_info["space_group_range"] = "Magnetic group (not supported)";
     nonmag_info["international_name"] += "1'";
     nonmag_info["name"] += "'";
-    nonmag_info["latex_name"].insert(nonmag_info["latex_name"].find('_'), "'");
+    nonmag_info["latex_name"].append("'");
     return nonmag_info;
   }
 


### PR DESCRIPTION
- When trying to write latex name for magnetic groups it's using `non_maginfo["latex_name"]` and adding `'` before `_`
- This is done by finding `_` in `non_maginfo["latex_name"]` and inserting `'` before it.
- But in the cases where `non_maginfo["latex_name"]` doesn't contain `_`, (for example `O` or `T`), this causes failure.
- Instead of finding `_` and adding `'` before it, I am just appending `'` to the end of the string. Because in latex, `O'_h` is the same as `O_h'`