### PR TITLE
fix site has_dof

### DIFF
--- a/include/casm/casm_io/json/optional.hh
+++ b/include/casm/casm_io/json/optional.hh
@@ -1,6 +1,8 @@
 #ifndef CASM_json_optional
 #define CASM_json_optional
 
+#include <optional>
+
 namespace CASM {
 
 template <typename T>

--- a/include/casm/crystallography/Site.hh
+++ b/include/casm/crystallography/Site.hh
@@ -13,6 +13,7 @@
 namespace CASM {
 namespace xtal {
 
+const std::string OCC_DOF = "occ";
 struct SymOp;
 class Molecule;
 

--- a/src/casm/crystallography/Site.cc
+++ b/src/casm/crystallography/Site.cc
@@ -88,8 +88,7 @@ SiteDoFSet const &Site::dof(std::string const &_dof_type) const {
 
 //****************************************************
 bool Site::has_dof(std::string const &_dof_type) const {
-  return occupant_dof().size() > 1 ||
-         m_dof_map.find(_dof_type) != m_dof_map.end();
+  return m_dof_map.find(_dof_type) != m_dof_map.end();
 }
 
 //****************************************************

--- a/src/casm/crystallography/Site.cc
+++ b/src/casm/crystallography/Site.cc
@@ -88,7 +88,8 @@ SiteDoFSet const &Site::dof(std::string const &_dof_type) const {
 
 //****************************************************
 bool Site::has_dof(std::string const &_dof_type) const {
-  return m_dof_map.find(_dof_type) != m_dof_map.end();
+  return (_dof_type == OCC_DOF && occupant_dof().size() > 1) ||
+         m_dof_map.find(_dof_type) != m_dof_map.end();
 }
 
 //****************************************************

--- a/src/casm/monte_carlo/canonical/CanonicalSettings.cc
+++ b/src/casm/monte_carlo/canonical/CanonicalSettings.cc
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "casm/enumerator/io/json/DoFSpace.hh"
 #include "casm/monte_carlo/canonical/CanonicalConditions.hh"
 #include "casm/monte_carlo/canonical/CanonicalIO.hh"


### PR DESCRIPTION
- Currently `Site::has_dof(_dof_type)` tells whether a particular `_dof_type` is present on the `Site` by either counting `occ_dofs` on the `Site` or if you could find `_dof_type` in the dof map.

- For example, if you have a prim where on one site you have Cmagspin dof and on the other occ dof: This implementation causes issues because of the following reason:
-- While doing `_generate_basis_symreps()` (https://github.com/prisms-center/CASMcode/blob/1.X/src/casm/crystallography/Structure.cc#L241), it's looping through all the Sites and checks whether the Site has certain `dof_key` and skips the Site when it finds `has_dof(key)` as `false`.
-- In this, `has_dof("Cmagspin")` is returned to be `true` on site which doesn't have Cmagspin dof because occ dof is present. This causes failure in project construction.  
