### PR TITLE
Bug fix: Clexulator formulas for Monte Carlo for cluster size >1 and cluster multiplicity ==1

### DIFF
--- a/include/casm/clex/ClexBasisWriter_impl.hh
+++ b/include/casm/clex/ClexBasisWriter_impl.hh
@@ -510,6 +510,9 @@ std::vector<std::string> flower_function_cpp_strings(
   if (_clust_orbit.size() > 1) {
     prefix = "(";
     suffix = ") / " + std::to_string(_clust_orbit.size()) + ".";
+  } else if (equiv_ucc.size() > 1) {
+    prefix = "(";
+    suffix = ")";
   }
 
   // loop over equivalent clusters


### PR DESCRIPTION
Code generated to evaluate changes in correlations in Monte Carlo calculations was missing parentheses under certain conditions:

- If the cluster size >1 and the cluster multiplicity ==1, the formulas for the change in correlations due to an occupation change (site_deval_bfunc_* functions) are missing necessary parentheses.

Example, incorrect formula:

> template<typename Scalar>
> Scalar test_project_Clexulator::site_deval_bfunc_312_0_at_0(int occ_i, int occ_f) const {
>         return (m_occ_func_0_0[occ_f] - m_occ_func_0_0[occ_i]) * occ_func_0_0(8) * occ_func_0_0(9) * occ_func_0_0(11) * occ_func_0_0(12) * occ_func_0_0(18) + occ_func_0_0(5) * occ_func_0_0(7) * occ_func_0_0(10) * occ_func_0_0(17) * occ_func_0_0(12) + occ_func_0_0(4) * occ_func_0_0(6) * occ_func_0_0(16) * occ_func_0_0(10) * occ_func_0_0(11) + occ_func_0_0(2) * occ_func_0_0(3) * occ_func_0_0(15) * occ_func_0_0(7) * occ_func_0_0(9) + occ_func_0_0(1) * occ_func_0_0(14) * occ_func_0_0(3) * occ_func_0_0(6) * occ_func_0_0(8) + occ_func_0_0(13) * occ_func_0_0(1) * occ_func_0_0(2) * occ_func_0_0(4) * occ_func_0_0(5);
>       }

Example, expected formula:
> template<typename Scalar>
> Scalar test_project_Clexulator::site_deval_bfunc_312_0_at_0(int occ_i, int occ_f) const {
>         return (m_occ_func_0_0[occ_f] - m_occ_func_0_0[occ_i]) * (occ_func_0_0(8) * occ_func_0_0(9) * occ_func_0_0(11) * occ_func_0_0(12) * occ_func_0_0(18) + occ_func_0_0(5) * occ_func_0_0(7) * occ_func_0_0(10) * occ_func_0_0(17) * occ_func_0_0(12) + occ_func_0_0(4) * occ_func_0_0(6) * occ_func_0_0(16) * occ_func_0_0(10) * occ_func_0_0(11) + occ_func_0_0(2) * occ_func_0_0(3) * occ_func_0_0(15) * occ_func_0_0(7) * occ_func_0_0(9) + occ_func_0_0(1) * occ_func_0_0(14) * occ_func_0_0(3) * occ_func_0_0(6) * occ_func_0_0(8) + occ_func_0_0(13) * occ_func_0_0(1) * occ_func_0_0(2) * occ_func_0_0(4) * occ_func_0_0(5));
>       }

Notes:

- The mean and site-centric basis functions formulas were correct
- The incorrect formulas are used in Monte Carlo calculations when the supercell size is large enough to avoid neighbor list overlap
- Clusters with multiplicity == 1 (except for null and point clusters which are not affected by this) do not occur for high-symmetry cubic and hexagonal parent structures until the cluster size is large. In this case, the problem was noticed when a  6-site cluster with non-zero eci was being used.
- If the issue occurred, it would affect results if the corresponding ECI was non-zero, or if that correlation, as calculated during Monte Carlo, was being used in a post-calculation analysis
- Lower symmetry parent structures, where the issue arises for small clusters, are more likely to be affected

