### PR TITLE
StrainConverter from BIOT to STRAIN_B

### DIFF
--- a/src/casm/clex/Configuration.cc
+++ b/src/casm/clex/Configuration.cc
@@ -891,7 +891,7 @@ double lattice_deformation(const Configuration &_config) {
 
 /// \brief Change in volume due to relaxation, expressed as the ratio V/V_0
 double volume_relaxation(const Configuration &_config) {
-  StrainConverter tconvert("BIOT");
+  StrainConverter tconvert("STRAIN_B");
   return tconvert.rollup_E(_config.calc_properties().global.at("Ustrain"))
       .determinant();
 }


### PR DESCRIPTION
- Fixes #282 
- When querying `volume_relaxation`, `StrainConverter` is using `BIOT` instead of `STRAIN_B` for BIOT strain metric.