### PR TITLE
fix bug while reading LocalContinuousConfigDoFValues from standard values

### DIFF
--- a/src/casm/clex/ConfigDoFValues.cc
+++ b/src/casm/clex/ConfigDoFValues.cc
@@ -147,13 +147,14 @@ void LocalContinuousConfigDoFValues::from_standard_values(
         << ", received cols=" << _standard_values.cols();
     throw std::runtime_error(msg.str());
   }
-  for (Index b = 0; b < n_sublat(); ++b){
-    if (info()[b].symrep_ID().empty()){
-        continue;
+  for (Index b = 0; b < n_sublat(); ++b) {
+    if (info()[b].symrep_ID().empty()) {
+      continue;
     }
     sublat(b).topRows(info()[b].dim()) =
         info()[b].inv_basis() *
-        _standard_values.block(0, b * n_vol(), m_vals.rows(), n_vol());
+        _standard_values.block(0, b * n_vol(), info().front().basis().rows(),
+                               n_vol());
   }
 }
 


### PR DESCRIPTION
When trying to construct `LocalContinuousConfigDoFValues` from `standard_values`:
- For a sublattice `b` to get the dof values: `inv_basis` of the DoF is being multiplied with a block of `standard_values` corresponding to that sublattice.
- When accessing the block of `standard_values` corresponding to that sublattice, the number of rows of the block size should be the number of rows corresponding to the standard basis.

For example in case of a disp dof, when there are 4 sublattices and for a vol 1 cell:
- Let's say the `basis` is a `3x2` matrix -> `inv_basis` will be a `2x3` matrix.
- `standard_values` is a `3x4` matrix for vol 1 config.
- local dof value corresponding to sublattice 1 should be `inv_basis` multiplied by the 2nd column of standard basis.
- Instead of doing this, the previous code multiplies `inv_basis` (`2x3`) matrix with a `2x1` block of standard basis because it is asking for a block size with `m_vals.rows()` instead of the `info().front().basis().rows()` block size. 


 