### PR TITLE
Bug squashing in DiffClexParamPack

### DIFF
--- a/include/casm/clex/ClexBasisWriter_impl.hh
+++ b/include/casm/clex/ClexBasisWriter_impl.hh
@@ -184,7 +184,6 @@ void ClexBasisWriter::print_clexulator(std::string class_name,
   stream
       << "#include <cstddef>\n"
       << "#include \"casm/clexulator/BaseClexulator.hh\"\n"
-      << "#include \"casm/clexulator/BasicClexParamPack.hh\"\n"
       << "#include \"casm/global/eigen.hh\"\n"
       << (m_param_pack_mix_in->cpp_includes_string()) << "\n"
       << "\n\n\n"

--- a/include/casm/clexulator/BasicClexParamPack.hh
+++ b/include/casm/clexulator/BasicClexParamPack.hh
@@ -157,39 +157,6 @@ class BasicClexParamPack : public ClexParamPack {
   std::vector<EvalMode> m_eval;
 };
 
-template <>
-struct ValAccess<double> {
-  using size_type = BasicClexParamPack::size_type;
-
-  static double const &get(BasicClexParamPack const &_pack,
-                           BasicClexParamKey const &_key, size_type i) {
-    return _pack.m_data[_key.index()](i, 0);
-  }
-
-  static double const &get(BasicClexParamPack const &_pack,
-                           BasicClexParamKey const &_key, size_type i,
-                           size_type j) {
-    return _pack.m_data[_key.index()](i, j);
-  }
-
-  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
-                  Eigen::Ref<const Eigen::MatrixXd> const &_val) {
-    _pack.m_data[_key.index()] = _val;
-  }
-
-  template <typename Scalar2>
-  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
-                  size_type i, Scalar2 const &_val) {
-    _pack.m_data[_key.index()](i, 0) = _val;
-  }
-
-  template <typename Scalar2>
-  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
-                  size_type i, size_type j, Scalar2 const &_val) {
-    _pack.m_data[_key.index()](i, j) = _val;
-  }
-};
-
 }  // namespace clexulator
 
 template <>

--- a/include/casm/clexulator/BasicClexParamPack.hh
+++ b/include/casm/clexulator/BasicClexParamPack.hh
@@ -157,6 +157,39 @@ class BasicClexParamPack : public ClexParamPack {
   std::vector<EvalMode> m_eval;
 };
 
+template <>
+struct ValAccess<double> {
+  using size_type = BasicClexParamPack::size_type;
+
+  static double const &get(BasicClexParamPack const &_pack,
+                           BasicClexParamKey const &_key, size_type i) {
+    return _pack.m_data[_key.index()](i, 0);
+  }
+
+  static double const &get(BasicClexParamPack const &_pack,
+                           BasicClexParamKey const &_key, size_type i,
+                           size_type j) {
+    return _pack.m_data[_key.index()](i, j);
+  }
+
+  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
+                  Eigen::Ref<const Eigen::MatrixXd> const &_val) {
+    _pack.m_data[_key.index()] = _val;
+  }
+
+  template <typename Scalar2>
+  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
+                  size_type i, Scalar2 const &_val) {
+    _pack.m_data[_key.index()](i, 0) = _val;
+  }
+
+  template <typename Scalar2>
+  static void set(BasicClexParamPack &_pack, BasicClexParamKey const &_key,
+                  size_type i, size_type j, Scalar2 const &_val) {
+    _pack.m_data[_key.index()](i, j) = _val;
+  }
+};
+
 }  // namespace clexulator
 
 template <>

--- a/include/casm/clexulator/ClexParamPack.hh
+++ b/include/casm/clexulator/ClexParamPack.hh
@@ -4,6 +4,8 @@
 #include <map>
 #include <vector>
 
+#include "casm/external/Eigen/Core"
+#include "casm/global/definitions.hh"
 #include "casm/misc/cloneable_ptr.hh"
 
 namespace CASM {

--- a/include/casm/clexulator/DiffClexParamPack.hh
+++ b/include/casm/clexulator/DiffClexParamPack.hh
@@ -485,15 +485,6 @@ class DiffClexParamHessKey : public DiffClexParamKey {
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 template <>
-struct traits<DiffClexParamPack::EvalMode> {
-  static const std::string name;
-
-  static const std::multimap<DiffClexParamPack::EvalMode,
-                             std::vector<std::string> >
-      strval;
-};
-
-template <>
 struct ValAccess<double> {
   using size_type = DiffClexParamPack::size_type;
 
@@ -671,6 +662,15 @@ inline DiffClexParamPack::Key DiffClexParamPack::allocate(
 }
 
 }  // namespace clexulator
+
+template <>
+struct traits<clexulator::DiffClexParamPack::EvalMode> {
+  static const std::string name;
+
+  static const std::multimap<clexulator::DiffClexParamPack::EvalMode,
+                             std::vector<std::string> >
+      strval;
+};
 
 inline std::ostream &operator<<(
     std::ostream &sout, const clexulator::DiffClexParamPack::EvalMode &val) {


### PR DESCRIPTION
- Moved template specialization of struct `traits` from namespace `CASM::clexulator` to `CASM` as the initialization of `traits` is in `CASM` namespace
- Removed `casm/clexulator/BasicClexParamPack.hh` header writing in `ClexBasisWriter` as it will be automatically taken care of by `m_param_pack_mix_in->cpp_includes_string()`. If left it causes issues with multiple definitions of `ValAccess<double>` in `BasicClexParamPack.hh` and `DiffClexParamPack.hh`
- Added missing includes in `ClexParamPack.hh` 

Squashing these bugs allows the use of `"param_pack_type": "DIFF"` in `bspecs.json` to compile a clexulator capable of doing gradients of correlations