### PR TITLE
enforce set_configdofvalues to avoid segfaults

### DIFF
--- a/include/casm/clex/Clexulator.hh
+++ b/include/casm/clex/Clexulator.hh
@@ -137,6 +137,26 @@ class Clexulator {
     return m_clex->weight_matrix();
   }
 
+  /// \brief Return sublat_indices
+  const std::set<int> &sublat_indices() const {
+    return m_clex->sublat_indices();
+  }
+
+  /// \brief Return n_sublattices
+  size_type n_sublattices() const { return m_clex->n_sublattices(); }
+
+  /// \brief Set the pointer to DoF values
+  ///
+  /// Notes:
+  /// - There is a small overhead that could be avoided by setting this
+  ///   manually only when the configuration being calculated is changed, but
+  ///   currently for safety this is called by the `calc_X` methods everytime
+  ///   and no savings are possible.
+  ///
+  void set_configdofvalues(ConfigDoF const &configdof) const {
+    m_clex->set_configdofvalues(configdof.values(), true);
+  }
+
   /// \brief Calculate contribution to global correlations from one unit cell
   ///
   /// \param _corr_begin Pointer to beginning of data structure where

--- a/include/casm/clexulator/BaseClexulator.hh
+++ b/include/casm/clexulator/BaseClexulator.hh
@@ -99,38 +99,37 @@ class BaseClexulator {
   ///
   /// \param _configdofvalues DoF values to be used as input to the basis
   ///      functions
-  /// \param _force
+  /// \param _force This option is deprecated, pointers are now always reset
+  ///      for safety
   ///
   /// Notes:
   /// - In the vast majority of cases this is handled by the `calc_X` method
   void set_configdofvalues(ConfigDoFValues const &_configdofvalues,
                            bool _force = false) const {
-    if (m_configdofvalues_ptr != &_configdofvalues || _force) {
-      m_configdofvalues_ptr = &_configdofvalues;
-      m_occ_ptr = _configdofvalues.occupation.data();
-      for (auto const &dof : m_local_dof_registry) {
-        auto it = _configdofvalues.local_dof_values.find(dof.first);
-        if (it == _configdofvalues.local_dof_values.end()) {
-          std::stringstream msg;
-          msg << "Clexulator error: ConfigDoFValues missing required local DoF "
-                 "type '"
-              << dof.first << "'";
-          throw std::runtime_error(msg.str());
-        }
-        m_local_dof_ptrs[dof.second] = &it->second;
+    m_configdofvalues_ptr = &_configdofvalues;
+    m_occ_ptr = _configdofvalues.occupation.data();
+    for (auto const &dof : m_local_dof_registry) {
+      auto it = _configdofvalues.local_dof_values.find(dof.first);
+      if (it == _configdofvalues.local_dof_values.end()) {
+        std::stringstream msg;
+        msg << "Clexulator error: ConfigDoFValues missing required local DoF "
+               "type '"
+            << dof.first << "'";
+        throw std::runtime_error(msg.str());
       }
+      m_local_dof_ptrs[dof.second] = &it->second;
+    }
 
-      for (auto const &dof : m_global_dof_registry) {
-        auto it = _configdofvalues.global_dof_values.find(dof.first);
-        if (it == _configdofvalues.global_dof_values.end()) {
-          std::stringstream msg;
-          msg << "Clexulator error: ConfigDoFValues missing required global "
-                 "DoF type '"
-              << dof.first << "'";
-          throw std::runtime_error(msg.str());
-        }
-        m_global_dof_ptrs[dof.second] = &it->second;
+    for (auto const &dof : m_global_dof_registry) {
+      auto it = _configdofvalues.global_dof_values.find(dof.first);
+      if (it == _configdofvalues.global_dof_values.end()) {
+        std::stringstream msg;
+        msg << "Clexulator error: ConfigDoFValues missing required global "
+               "DoF type '"
+            << dof.first << "'";
+        throw std::runtime_error(msg.str());
       }
+      m_global_dof_ptrs[dof.second] = &it->second;
     }
   }
 

--- a/src/casm/monte_carlo/MonteCarloEnum.cc
+++ b/src/casm/monte_carlo/MonteCarloEnum.cc
@@ -149,7 +149,6 @@ void MonteCarloEnum::save_configs(bool dry_run) {
   _log() << "configuration enumeration metric: " << m_metric_args << "\n";
   _log() << flag << formatter(halloffame().begin(), halloffame().end());
   _log() << std::endl;
-  std::cout << "save_configs 19" << std::endl;
 }
 
 void MonteCarloEnum::print_info() const {


### PR DESCRIPTION
This enforces that pointers to ConfigDoFValues are always reset, to avoid segfaults when evaluating the cluster expansion basis functions.