### PR TITLE
Super fix

### DIFF
--- a/src/casm/app/super.cc
+++ b/src/casm/app/super.cc
@@ -54,70 +54,59 @@ void SuperOption::initialize() {
   add_configlists_nodefault_suboption();
   add_coordtype_suboption();
 
-  m_desc.add_options()("transf-mat",
-                       po::value<std::vector<fs::path> >(&m_transf_mat_paths)
-                           ->multitoken()
-                           ->value_name(ArgHandler::path()),
-                       "1 or more files containing a 3x3 transformation matrix "
-                       "used to create a supercell.")
+  m_desc.add_options()(
+      "transf-mat",
+      po::value<std::vector<fs::path> >(&m_transf_mat_paths)
+      ->multitoken()
+      ->value_name(ArgHandler::path()),
+      "One or more files containing a 3x3 transformation matrix used to create "
+      "a supercell.")(
 
-      ("get-transf-mat", "If it exists, find the transformation matrix.")
+      "get-transf-mat",
+      "If it exists, find the transformation matrix.")(
 
-          ("structure",
-           po::value<fs::path>(&m_struct_path)->value_name(ArgHandler::path()),
-           "File with structure (POSCAR type) to use.")
+      "structure",
+      po::value<fs::path>(&m_struct_path)->value_name(ArgHandler::path()),
+      "File with structure (POSCAR type) to use.")(
 
-              ("unitcell",
-               po::value<std::string>(&m_unit_scel_str)
-                   ->value_name(ArgHandler::supercell()),
-               "Name of supercell to use as unit cell. For ex. "
-               "'SCEL2_2_1_1_0_0_0'.")
+      "unitcell",
+      po::value<std::string>(&m_unit_scel_str)
+      ->value_name(ArgHandler::supercell()),
+      "Name of supercell to use as unit cell. For ex. 'SCEL2_2_1_1_0_0_0'.")(
 
-                  ("duper",
-                   "Construct the superduperlattice, the minimum supercell of "
-                   "all input supercells "
-                   "and configurations.")
+      "duper",
+      "Construct the superduperlattice, the minimum supercell of all input "
+      "supercells and configurations.")(
 
-                      ("fixed-orientation",
-                       "When constructing the superduperlattice, do not "
-                       "consider other symmetrically "
-                       "equivalent orientations.")
+      "fixed-orientation",
+      "When constructing the superduperlattice, do not consider other "
+      "symmetrically equivalent orientations.")(
 
-                          ("min-volume", po::value<Index>(&m_min_vol),
-                           "Transforms the transformation matrix, T -> T', "
-                           "where T' = T*M, such that "
-                           "(T').determininant() >= V. This has the effect "
-                           "that a supercell has a "
-                           "particular volume.")
+      "min-volume", po::value<Index>(&m_min_vol),
+      "Transforms the transformation matrix, T -> T', where T' = T*M, "
+      "such that (T').determininant() >= V. This has the effect "
+      "that a supercell has a particular volume.")(
 
-                              ("fixed-shape",
-                               "Used with --min-volume to enforce that T' = "
-                               "T*m*I, where I is the identity "
-                               "matrix, and m is a scalar. This has the effect "
-                               "of preserving the shape "
-                               "of the resulting supercell, but increasing the "
-                               "volume.")
+      "fixed-shape",
+      "Used with --min-volume to enforce that T' = T*m*I, where I is the "
+      "identity matrix, and m is a scalar. This has the effect of preserving "
+      "the shape of the resulting supercell, but increasing the volume.")(
 
-                                  ("verbose",
-                                   "When used with --duper, show how the input "
-                                   "lattices are transformed "
-                                   "to tile the superduperlattice.")
+      "verbose",
+      "When used with --duper, show how the input lattices are transformed to "
+      "tile the superduperlattice.")(
 
-                                      ("add-canonical,a",
-                                       "Will add the generated super "
-                                       "configuration in it's "
-                                       "canonical form in the equivalent "
-                                       "niggli supercell.")
+      "add-canonical,a",
+      "Will add the generated super configuration in its canonical form in the "
+      "equivalent niggli supercell.")(
 
-                                          ("vasp5",
-                                           "Print using VASP5 style (include "
-                                           "atom name line)")
+      "vasp5",
+      "Print using VASP5 style (include atom name line).")(
 
-                                              ("tol",
-                                               po::value<double>(&m_tolerance)
-                                                   ->default_value(CASM::TOL),
-                                               "Tolerance used for checking "
-                                               "symmetry");
+      "tol",
+      po::value<double>(&m_tolerance)
+      ->default_value(CASM::TOL),
+      "Tolerance used for checking symmetry");
 
   return;
 }
@@ -222,36 +211,36 @@ int super_command(const CommandArgs &args) {
     }
 
     else {
-          po::notify(vm);  // throws on error, so do after help in case
-	  // there are any problems
+      po::notify(vm);  // throws on error, so do after help in case
+      // there are any problems
 
-	  scelname = super_opt.supercell_strs();
-	  configname = super_opt.config_strs();
-	  unitscelname = super_opt.unit_scel_str();
-	  structfile = super_opt.struct_path();
-	  tmatfile = super_opt.transf_mat_paths();
-	  config_path = super_opt.selection_paths();
-	  min_vol = super_opt.min_vol();
-	  tol = super_opt.tolerance();
-	  coordtype = super_opt.coordtype_enum();      
+      scelname = super_opt.supercell_strs();
+      configname = super_opt.config_strs();
+      unitscelname = super_opt.unit_scel_str();
+      structfile = super_opt.struct_path();
+      tmatfile = super_opt.transf_mat_paths();
+      config_path = super_opt.selection_paths();
+      min_vol = super_opt.min_vol();
+      tol = super_opt.tolerance();
+      coordtype = super_opt.coordtype_enum();
       if (!vm.count("duper")) {
         if (vm.count("transf-mat") + vm.count("get-transf-mat") != 1) {
           err_log() << "Error in 'casm super'. Only one of --transf-mat or "
-                       "--get-transf-mat may be chosen."
+              "--get-transf-mat may be chosen."
                     << std::endl;
           return ERR_INVALID_ARG;
         }
         if (configname.size() > 1 || scelname.size() > 1 ||
             tmatfile.size() > 1) {
           err_log() << "ERROR: more than one --confignames, --scelnames, or "
-                       "--transf-mat argument "
-                       "is only allowed for option --duper"
+              "--transf-mat argument "
+              "is only allowed for option --duper"
                     << std::endl;
           return ERR_INVALID_ARG;
         }
         if (config_path.size() > 0) {
           err_log() << "ERROR: the --configs option is only allowed with "
-                       "option --duper"
+              "option --duper"
                     << std::endl;
           return ERR_INVALID_ARG;
         }

--- a/src/casm/app/super.cc
+++ b/src/casm/app/super.cc
@@ -699,7 +699,7 @@ int super_command(const CommandArgs &args) {
       super_lat =
           BasicStructure::from_poscar_stream(abs_structfile_stream).lattice();
     } else if (vm.count("scelnames")) {
-      super_lat = primclex.db<Supercell>().find(unitscelname)->lattice();
+      super_lat = primclex.db<Supercell>().find(scelname[0])->lattice();
     } else {
       log() << "Error in 'casm super --get-transf-mat'. No --structure or "
                "--scelnames given."

--- a/src/casm/app/super.cc
+++ b/src/casm/app/super.cc
@@ -150,31 +150,6 @@ int super_command(const CommandArgs &args) {
         po::parse_command_line(args.argc(), args.argv(), super_opt.desc()),
         vm);  // can throw
 
-    if (!vm.count("help") && !vm.count("desc")) {
-      if (!vm.count("duper")) {
-        if (vm.count("transf-mat") + vm.count("get-transf-mat") != 1) {
-          err_log() << "Error in 'casm super'. Only one of --transf-mat or "
-                       "--get-transf-mat may be chosen."
-                    << std::endl;
-          return ERR_INVALID_ARG;
-        }
-        if (configname.size() > 1 || scelname.size() > 1 ||
-            tmatfile.size() > 1) {
-          err_log() << "ERROR: more than one --confignames, --scelnames, or "
-                       "--transf-mat argument "
-                       "is only allowed for option --duper"
-                    << std::endl;
-          return ERR_INVALID_ARG;
-        }
-        if (config_path.size() > 0) {
-          err_log() << "ERROR: the --configs option is only allowed with "
-                       "option --duper"
-                    << std::endl;
-          return ERR_INVALID_ARG;
-        }
-      }
-    }
-
     /** --help option
      */
     if (vm.count("help")) {
@@ -184,7 +159,7 @@ int super_command(const CommandArgs &args) {
       return 0;
     }
 
-    if (vm.count("desc")) {
+    else if (vm.count("desc")) {
       log() << "\n";
       log() << super_opt.desc() << std::endl;
       log() << "DESCRIPTION" << std::endl;
@@ -246,18 +221,43 @@ int super_command(const CommandArgs &args) {
       return 0;
     }
 
-    po::notify(vm);  // throws on error, so do after help in case
-    // there are any problems
+    else {
+          po::notify(vm);  // throws on error, so do after help in case
+	  // there are any problems
 
-    scelname = super_opt.supercell_strs();
-    configname = super_opt.config_strs();
-    unitscelname = super_opt.unit_scel_str();
-    structfile = super_opt.struct_path();
-    tmatfile = super_opt.transf_mat_paths();
-    config_path = super_opt.selection_paths();
-    min_vol = super_opt.min_vol();
-    tol = super_opt.tolerance();
-    coordtype = super_opt.coordtype_enum();
+	  scelname = super_opt.supercell_strs();
+	  configname = super_opt.config_strs();
+	  unitscelname = super_opt.unit_scel_str();
+	  structfile = super_opt.struct_path();
+	  tmatfile = super_opt.transf_mat_paths();
+	  config_path = super_opt.selection_paths();
+	  min_vol = super_opt.min_vol();
+	  tol = super_opt.tolerance();
+	  coordtype = super_opt.coordtype_enum();      
+      if (!vm.count("duper")) {
+        if (vm.count("transf-mat") + vm.count("get-transf-mat") != 1) {
+          err_log() << "Error in 'casm super'. Only one of --transf-mat or "
+                       "--get-transf-mat may be chosen."
+                    << std::endl;
+          return ERR_INVALID_ARG;
+        }
+        if (configname.size() > 1 || scelname.size() > 1 ||
+            tmatfile.size() > 1) {
+          err_log() << "ERROR: more than one --confignames, --scelnames, or "
+                       "--transf-mat argument "
+                       "is only allowed for option --duper"
+                    << std::endl;
+          return ERR_INVALID_ARG;
+        }
+        if (config_path.size() > 0) {
+          err_log() << "ERROR: the --configs option is only allowed with "
+                       "option --duper"
+                    << std::endl;
+          return ERR_INVALID_ARG;
+        }
+      }
+    }
+
   } catch (po::error &e) {
     err_log() << "ERROR: " << e.what() << std::endl << std::endl;
     err_log() << super_opt.desc() << std::endl;


### PR DESCRIPTION
This pull request fixes the following bugs in `casm super` (#289): 

1. `casm super --scelnames scel1 --get-transf-mat` crashes
2. `casm super --scelnames scel1 --get-transf-mat --unitcell SCEL1_1_1_1_0_0_0` always returns the identity matrix
3. The `--confignames` and `--scelnames` options were only supposed to take one argument if `--duper` was not passed. This check was failing, so I fixed it, which also fixed some other `--duper` checks.

I also reformatted the `--help` output to match query.cc.

Two more comments:
1. By default, `casm super --scelnames scel --transf-mat T` or `casm super --duper` write to the supercell database, which I think should be optional. I can try to implement this if it sounds like a good idea.
2. The error handling is not consistent, e.g empty `casm super --duper`, `casm super --get-transf-mat`, and `casm super --transf-mat` all have different behavior. But, I think fixing this should be part of standardizing the app interfaces in general.