### PR TITLE
[WIP] Fix symop_matrices json output

### DIFF
--- a/src/casm/symmetry/io/json/SymRepTools.cc
+++ b/src/casm/symmetry/io/json/SymRepTools.cc
@@ -100,7 +100,7 @@ jsonParser &to_json(VectorSpaceSymReport const &obj, jsonParser &json) {
           json["irreducible_representations"]["symop_matrices"]
               [irrep_name];  //.put_array();
       for (Index o = 0; o < obj.symgroup_rep.size(); ++o) {
-        Eigen::MatrixXd const &op = obj.symgroup_rep[i];
+        Eigen::MatrixXd const &op = obj.symgroup_rep[o];
         std::string op_name =
             "op_" + to_sequential_string(o + 1, obj.symgroup_rep.size());
         irrep_matrices[op_name] =
@@ -253,7 +253,7 @@ jsonParser &to_json(SymRepTools_v2::VectorSpaceSymReport const &obj,
           json["irreducible_representations"]["symop_matrices"]
               [irrep_name];  //.put_array();
       for (Index o = 0; o < obj.symgroup_rep.size(); ++o) {
-        Eigen::MatrixXd const &op = obj.symgroup_rep[i];
+        Eigen::MatrixXd const &op = obj.symgroup_rep[o];
         std::string op_name =
             "op_" + to_sequential_string(o + 1, obj.symgroup_rep.size());
         irrep_matrices[op_name] =


### PR DESCRIPTION
`casm sym --dof-space-analysis` prints the same matrix for every op inside an irrep. I have made a change that results in different matrices being printed for different symops. I do not know what the rest of the code is doing, so I still have to check if they are the correct matrices.