### PR TITLE
[WIP] Mapping with deformation score

### DIFF
--- a/src/casm/clex/MappedProperties.cc
+++ b/src/casm/clex/MappedProperties.cc
@@ -172,6 +172,7 @@ jsonParser &to_json(const ScoreMappedProperties &score, jsonParser &json) {
       break;
     case ScoreMappedProperties::Method::deformation_cost:
       json["method"] = "deformation_cost";
+      json["lattice_weight"] = score.option().lattice_weight;
       break;
     case ScoreMappedProperties::Method::direct_selection:
       json["method"] = "direct_selection";
@@ -196,6 +197,7 @@ jsonParser const &from_json(ScoreMappedProperties &score,
     } else if (method == "deformation_cost") {
       opt.method = ScoreMappedProperties::Method::deformation_cost;
       opt.name = "";
+      opt.lattice_weight = json["lattice_weight"].get<double>();
     } else if (method == "direct_selection") {
       opt.method = ScoreMappedProperties::Method::direct_selection;
       opt.name = json["name"].get<std::string>();

--- a/src/casm/completer/Handlers.cc
+++ b/src/casm/completer/Handlers.cc
@@ -438,9 +438,9 @@ void OptionHandlerBase::add_configlist_suboption(const fs::path &_default) {
                            ->value_name(ArgHandler::path()),
                        (std::string("Only consider the selected configurations "
                                     "of the given selection file. ") +
-                        singleline_help<DB::SELECTION_TYPE>())
+                        standard_singleline_enum_help<DB::SELECTION_TYPE>(_default.string(), "filename"))
                            .c_str());
-  return;
+    return;
 }
 
 void OptionHandlerBase::add_selections_suboption(const fs::path &_default) {


### PR DESCRIPTION
This is my attempt to enable mapping with deformation_cost. Based on #292, I set `{"default_conflict_score" : {"method": "deformation_cost", "lattice_weight": 0.5}}` in my config_props.json. This switches the method to deformation cost, but the lattice weight is always set to -1 because the options for the default energy method have lattice weight set to -1 and the new value is not read. Now the report outputs the correct score, and the lattice weight can also be set in the input settings json. However, I do not think that the conflict scoring method can be set outside of config_props.json, and I am not certain the mapping is all working correctly because the default energy method options seem to be read every time ScoreMappedProperties are created.

I also updated `add_configlist_suboption` to set the passed default selection in the documentation because it always said MASTER was default regardless of what the default actually was (in this case ALL is set as default).

Finally, I was thinking about setting a check for positive lattice weight in `ScoreMappedProperties::validate but I do not think that function is called anywhere.

Changing the mapping may also change the scores of already mapped structures. `casm query` on the last conda release and on this branch give different atomic_deformation and lattice_deformation.

This needs to be tested for imports. The casm import documentation in 2) says:
```
- If multiple imported structures map onto the same configuration, 
       the properties from the structure with the best for 
       "conflict_score" are used when querying properties of the 
       configuration. By default, property "energy" is used for the 
       conflict score, minimum being best.
```
but in the settings section:
```
    lattice_weight: number in range [0.0, 1.0] (optional, default=0.5) 
        Candidate configurations are compared using "deformation_cost" to 
        determine the best mapping of the import structure to a             
        configuration. The "lattice_weight" determines the relative weight
        of the "lattice_deformation_cost" and "atomic_deformation_cost"  
        when calculating the total "deformation_cost". See _____ for      
        details.
```

When importing structure files with no energy, the lowest deformation cost structures are not selected and both "best_score" and "score" are null.