### PR TITLE
Fixes for symmetry adapted axes determination and output

### DIFF
--- a/src/casm/enumerator/DoFSpace.cc
+++ b/src/casm/enumerator/DoFSpace.cc
@@ -1131,7 +1131,11 @@ Eigen::MatrixXd make_homogeneous_mode_space(DoFSpace const &dof_space) {
       Eigen::MatrixXd::Identity(standard_basis_dim, standard_basis_dim);
   Eigen::MatrixXd prod = I;
   for (auto const &sublat_dof : prim_dof_info) {
-    prod = sublat_dof.basis() * sublat_dof.inv_basis() * prod;
+    if (sublat_dof.dim() == 0) {
+      prod *= 0.0;
+    } else {
+      prod = sublat_dof.basis() * sublat_dof.inv_basis() * prod;
+    }
   }
   // common_standard_basis is nullspace of (prod - I):
   Eigen::MatrixXd common_standard_basis =

--- a/src/casm/enumerator/io/dof_space_analysis.cc
+++ b/src/casm/enumerator/io/dof_space_analysis.cc
@@ -215,9 +215,11 @@ fs::path SymmetryDirectoryOutput::_output_dir(
 SequentialDirectoryOutput::SequentialDirectoryOutput(fs::path output_dir)
     : m_output_dir(output_dir) {
   if (fs::exists(m_output_dir / "dof_space")) {
-    throw std::runtime_error(
-        "Error in output_dof_space: \"dof_space\" directory "
-        "already exists. Will not overwrite.");
+    std::stringstream ss;
+    ss << "Error in output_dof_space: "
+       << fs::relative(m_output_dir / "dof_space")
+       << " already exists. Will not overwrite.";
+    throw std::runtime_error(ss.str());
   }
 }
 

--- a/src/casm/symmetry/io/json/SymRepTools.cc
+++ b/src/casm/symmetry/io/json/SymRepTools.cc
@@ -253,7 +253,7 @@ jsonParser &to_json(SymRepTools_v2::VectorSpaceSymReport const &obj,
           json["irreducible_representations"]["symop_matrices"]
               [irrep_name];  //.put_array();
       for (Index o = 0; o < obj.symgroup_rep.size(); ++o) {
-        Eigen::MatrixXd const &op = obj.symgroup_rep[i];
+        Eigen::MatrixXd const &op = obj.symgroup_rep[o];
         std::string op_name =
             "op_" + to_sequential_string(o + 1, obj.symgroup_rep.size());
         irrep_matrices[op_name] =


### PR DESCRIPTION
Calculating symmetry adapted axes was failing if one type of local continuous DoF (i.e. "disp") was not included on all sites. 

Additionally, there was an indexing error when outputting to JSON the symmetry representation matrices for transforming  each irreducible subspace. This resulted in incorrect matrices and sometimes segfaults.

This PR includes fixes for both issues.